### PR TITLE
Brought codebase to v3.1

### DIFF
--- a/initdb/init.sql
+++ b/initdb/init.sql
@@ -22,7 +22,7 @@ CREATE TYPE public.address_address_type_enum AS ENUM (
     'physical',
     'postal',
     'virtual'
-);
+    );
 
 
 ALTER TYPE public.address_address_type_enum OWNER TO postgres;
@@ -35,7 +35,7 @@ CREATE TYPE public.location_location_type_enum AS ENUM (
     'physical',
     'postal',
     'virtual'
-);
+    );
 
 
 ALTER TYPE public.location_location_type_enum OWNER TO postgres;
@@ -47,7 +47,7 @@ ALTER TYPE public.location_location_type_enum OWNER TO postgres;
 CREATE TYPE public.schedule_freq_enum AS ENUM (
     'WEEKLY',
     'MONTHLY'
-);
+    );
 
 
 ALTER TYPE public.schedule_freq_enum OWNER TO postgres;
@@ -64,7 +64,7 @@ CREATE TYPE public.schedule_wkst_enum AS ENUM (
     'FR',
     'SA',
     'SU'
-);
+    );
 
 
 ALTER TYPE public.schedule_wkst_enum OWNER TO postgres;
@@ -78,7 +78,7 @@ CREATE TYPE public.service_status_enum AS ENUM (
     'inactive',
     'defunct',
     'temporarily closed'
-);
+    );
 
 
 ALTER TYPE public.service_status_enum OWNER TO postgres;
@@ -91,16 +91,18 @@ SET default_table_access_method = heap;
 -- Name: accessibility; Type: TABLE; Schema: public; Owner: postgres
 --
 
-CREATE TABLE public.accessibility (
-    id character varying(250) NOT NULL,
+CREATE TABLE public.accessibility
+(
+    id          character varying(250) NOT NULL,
     location_id character varying(250),
     description text,
-    details text,
-    url text
+    details     text,
+    url         text
 );
 
 
-ALTER TABLE public.accessibility OWNER TO postgres;
+ALTER TABLE public.accessibility
+    OWNER TO postgres;
 
 --
 -- Name: COLUMN accessibility.id; Type: COMMENT; Schema: public; Owner: postgres
@@ -141,22 +143,24 @@ COMMENT ON COLUMN public.accessibility.url IS 'The URL of a page giving more inf
 -- Name: address; Type: TABLE; Schema: public; Owner: postgres
 --
 
-CREATE TABLE public.address (
-    id character varying(250) NOT NULL,
-    location_id character varying(250),
-    attention text,
-    address_1 text NOT NULL,
-    address_2 text,
-    city text NOT NULL,
-    region text,
-    state_province text NOT NULL,
-    postal_code text NOT NULL,
-    country text NOT NULL,
-    address_type public.address_address_type_enum NOT NULL
+CREATE TABLE public.address
+(
+    id             character varying(250)           NOT NULL,
+    location_id    character varying(250),
+    attention      text,
+    address_1      text                             NOT NULL,
+    address_2      text,
+    city           text                             NOT NULL,
+    region         text,
+    state_province text                             NOT NULL,
+    postal_code    text                             NOT NULL,
+    country        text                             NOT NULL,
+    address_type   public.address_address_type_enum NOT NULL
 );
 
 
-ALTER TABLE public.address OWNER TO postgres;
+ALTER TABLE public.address
+    OWNER TO postgres;
 
 --
 -- Name: COLUMN address.id; Type: COMMENT; Schema: public; Owner: postgres
@@ -239,17 +243,20 @@ COMMENT ON COLUMN public.address.address_type IS 'The type of address which may 
 -- Name: attribute; Type: TABLE; Schema: public; Owner: postgres
 --
 
-CREATE TABLE public.attribute (
-    id character varying(250) NOT NULL,
-    link_id text NOT NULL,
+CREATE TABLE public.attribute
+(
+    id               character varying(250) NOT NULL,
+    link_id          text                   NOT NULL,
     taxonomy_term_id character varying(250) NOT NULL,
-    link_type text,
-    link_entity text NOT NULL,
-    value text
+    link_type        text,
+    link_entity      text                   NOT NULL,
+    value            text,
+    label            text
 );
 
 
-ALTER TABLE public.attribute OWNER TO postgres;
+ALTER TABLE public.attribute
+    OWNER TO postgres;
 
 --
 -- Name: COLUMN attribute.id; Type: COMMENT; Schema: public; Owner: postgres
@@ -294,23 +301,32 @@ COMMENT ON COLUMN public.attribute.value IS 'The value (if any) of an attribute.
 
 
 --
+-- Name: COLUMN attribute.label; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON COLUMN public.attribute.label IS 'A free text label of the attribute.';
+
+
+--
 -- Name: contact; Type: TABLE; Schema: public; Owner: postgres
 --
 
-CREATE TABLE public.contact (
-    id character varying(250) NOT NULL,
-    organization_id character varying(250),
-    service_id character varying(250),
+CREATE TABLE public.contact
+(
+    id                     character varying(250) NOT NULL,
+    organization_id        character varying(250),
+    service_id             character varying(250),
     service_at_location_id character varying(250),
-    location_id character varying(250),
-    name text,
-    title text,
-    department text,
-    email text
+    location_id            character varying(250),
+    name                   text,
+    title                  text,
+    department             text,
+    email                  text
 );
 
 
-ALTER TABLE public.contact OWNER TO postgres;
+ALTER TABLE public.contact
+    OWNER TO postgres;
 
 --
 -- Name: COLUMN contact.id; Type: COMMENT; Schema: public; Owner: postgres
@@ -379,19 +395,21 @@ COMMENT ON COLUMN public.contact.email IS 'The email address of the contact.';
 -- Name: cost_option; Type: TABLE; Schema: public; Owner: postgres
 --
 
-CREATE TABLE public.cost_option (
-    id character varying(250) NOT NULL,
-    service_id character varying(250) NOT NULL,
-    valid_from date,
-    valid_to date,
-    option text,
-    currency text,
-    amount numeric,
+CREATE TABLE public.cost_option
+(
+    id                 character varying(250) NOT NULL,
+    service_id         character varying(250) NOT NULL,
+    valid_from         date,
+    valid_to           date,
+    option             text,
+    currency           text,
+    amount             numeric,
     amount_description text
 );
 
 
-ALTER TABLE public.cost_option OWNER TO postgres;
+ALTER TABLE public.cost_option
+    OWNER TO postgres;
 
 --
 -- Name: COLUMN cost_option.id; Type: COMMENT; Schema: public; Owner: postgres
@@ -453,15 +471,17 @@ COMMENT ON COLUMN public.cost_option.amount_description IS 'Specific details qua
 -- Name: funding; Type: TABLE; Schema: public; Owner: postgres
 --
 
-CREATE TABLE public.funding (
-    id character varying(250) NOT NULL,
+CREATE TABLE public.funding
+(
+    id              character varying(250) NOT NULL,
     organization_id character varying(250),
-    service_id character varying(250),
-    source text
+    service_id      character varying(250),
+    source          text
 );
 
 
-ALTER TABLE public.funding OWNER TO postgres;
+ALTER TABLE public.funding
+    OWNER TO postgres;
 
 --
 -- Name: COLUMN funding.id; Type: COMMENT; Schema: public; Owner: postgres
@@ -495,18 +515,20 @@ COMMENT ON COLUMN public.funding.source IS 'A free text description of the sourc
 -- Name: language; Type: TABLE; Schema: public; Owner: postgres
 --
 
-CREATE TABLE public.language (
-    id character varying(250) NOT NULL,
-    service_id character varying(250),
+CREATE TABLE public.language
+(
+    id          character varying(250) NOT NULL,
+    service_id  character varying(250),
     location_id character varying(250),
-    phone_id character varying(250),
-    name text,
-    code text,
-    note text
+    phone_id    character varying(250),
+    name        text,
+    code        text,
+    note        text
 );
 
 
-ALTER TABLE public.language OWNER TO postgres;
+ALTER TABLE public.language
+    OWNER TO postgres;
 
 --
 -- Name: COLUMN language.id; Type: COMMENT; Schema: public; Owner: postgres
@@ -561,23 +583,25 @@ COMMENT ON COLUMN public.language.note IS 'A free text description of any additi
 -- Name: location; Type: TABLE; Schema: public; Owner: postgres
 --
 
-CREATE TABLE public.location (
-    id character varying(250) NOT NULL,
-    location_type public.location_location_type_enum NOT NULL,
-    url text,
-    organization_id character varying(250),
-    name text,
-    alternate_name text,
-    description text,
-    transportation text,
-    latitude numeric,
-    longitude numeric,
-    external_identifier text,
+CREATE TABLE public.location
+(
+    id                       character varying(250)             NOT NULL,
+    location_type            public.location_location_type_enum NOT NULL,
+    url                      text,
+    organization_id          character varying(250),
+    name                     text,
+    alternate_name           text,
+    description              text,
+    transportation           text,
+    latitude                 numeric,
+    longitude                numeric,
+    external_identifier      text,
     external_identifier_type text
 );
 
 
-ALTER TABLE public.location OWNER TO postgres;
+ALTER TABLE public.location
+    OWNER TO postgres;
 
 --
 -- Name: COLUMN location.id; Type: COMMENT; Schema: public; Owner: postgres
@@ -667,15 +691,17 @@ COMMENT ON COLUMN public.location.external_identifier_type IS 'The scheme used f
 -- Name: meta_table_description; Type: TABLE; Schema: public; Owner: postgres
 --
 
-CREATE TABLE public.meta_table_description (
-    id character varying(250) NOT NULL,
-    name text,
-    language text,
+CREATE TABLE public.meta_table_description
+(
+    id            character varying(250) NOT NULL,
+    name          text,
+    language      text,
     character_set text
 );
 
 
-ALTER TABLE public.meta_table_description OWNER TO postgres;
+ALTER TABLE public.meta_table_description
+    OWNER TO postgres;
 
 --
 -- Name: COLUMN meta_table_description.id; Type: COMMENT; Schema: public; Owner: postgres
@@ -709,20 +735,22 @@ COMMENT ON COLUMN public.meta_table_description.character_set IS 'The character 
 -- Name: metadata; Type: TABLE; Schema: public; Owner: postgres
 --
 
-CREATE TABLE public.metadata (
-    id character varying(250) NOT NULL,
-    resource_id text NOT NULL,
-    resource_type text NOT NULL,
-    last_action_date date NOT NULL,
-    last_action_type text NOT NULL,
-    field_name text NOT NULL,
-    previous_value text NOT NULL,
-    replacement_value text NOT NULL,
-    updated_by text NOT NULL
+CREATE TABLE public.metadata
+(
+    id                character varying(250) NOT NULL,
+    resource_id       text                   NOT NULL,
+    resource_type     text                   NOT NULL,
+    last_action_date  date                   NOT NULL,
+    last_action_type  text                   NOT NULL,
+    field_name        text                   NOT NULL,
+    previous_value    text                   NOT NULL,
+    replacement_value text                   NOT NULL,
+    updated_by        text                   NOT NULL
 );
 
 
-ALTER TABLE public.metadata OWNER TO postgres;
+ALTER TABLE public.metadata
+    OWNER TO postgres;
 
 --
 -- Name: COLUMN metadata.id; Type: COMMENT; Schema: public; Owner: postgres
@@ -791,24 +819,26 @@ COMMENT ON COLUMN public.metadata.updated_by IS 'The name of the person who modi
 -- Name: organization; Type: TABLE; Schema: public; Owner: postgres
 --
 
-CREATE TABLE public.organization (
-    id character varying(250) NOT NULL,
-    name text NOT NULL,
-    alternate_name text,
-    description text NOT NULL,
-    email text,
-    website text,
-    tax_status text,
-    tax_id text,
-    year_incorporated numeric,
-    legal_status text,
-    logo text,
-    uri text,
+CREATE TABLE public.organization
+(
+    id                     character varying(250) NOT NULL,
+    name                   text                   NOT NULL,
+    alternate_name         text,
+    description            text                   NOT NULL,
+    email                  text,
+    website                text,
+    tax_status             text,
+    tax_id                 text,
+    year_incorporated      numeric,
+    legal_status           text,
+    logo                   text,
+    uri                    text,
     parent_organization_id text
 );
 
 
-ALTER TABLE public.organization OWNER TO postgres;
+ALTER TABLE public.organization
+    OWNER TO postgres;
 
 --
 -- Name: COLUMN organization.id; Type: COMMENT; Schema: public; Owner: postgres
@@ -905,16 +935,18 @@ COMMENT ON COLUMN public.organization.parent_organization_id IS 'The identifier 
 -- Name: organization_identifier; Type: TABLE; Schema: public; Owner: postgres
 --
 
-CREATE TABLE public.organization_identifier (
-    id character varying(250) NOT NULL,
-    organization_id character varying(250) NOT NULL,
+CREATE TABLE public.organization_identifier
+(
+    id                character varying(250) NOT NULL,
+    organization_id   character varying(250) NOT NULL,
     identifier_scheme text,
-    identifier_type text NOT NULL,
-    identifier text NOT NULL
+    identifier_type   text                   NOT NULL,
+    identifier        text                   NOT NULL
 );
 
 
-ALTER TABLE public.organization_identifier OWNER TO postgres;
+ALTER TABLE public.organization_identifier
+    OWNER TO postgres;
 
 --
 -- Name: COLUMN organization_identifier.id; Type: COMMENT; Schema: public; Owner: postgres
@@ -955,21 +987,23 @@ COMMENT ON COLUMN public.organization_identifier.identifier IS 'The third-party 
 -- Name: phone; Type: TABLE; Schema: public; Owner: postgres
 --
 
-CREATE TABLE public.phone (
-    id character varying(250) NOT NULL,
-    location_id character varying(250),
-    service_id character varying(250),
-    organization_id character varying(250),
-    contact_id character varying(250),
+CREATE TABLE public.phone
+(
+    id                     character varying(250) NOT NULL,
+    location_id            character varying(250),
+    service_id             character varying(250),
+    organization_id        character varying(250),
+    contact_id             character varying(250),
     service_at_location_id character varying(250),
-    number text NOT NULL,
-    extension numeric,
-    type text,
-    description text
+    number                 text                   NOT NULL,
+    extension              numeric,
+    type                   text,
+    description            text
 );
 
 
-ALTER TABLE public.phone OWNER TO postgres;
+ALTER TABLE public.phone
+    OWNER TO postgres;
 
 --
 -- Name: COLUMN phone.id; Type: COMMENT; Schema: public; Owner: postgres
@@ -1045,16 +1079,18 @@ COMMENT ON COLUMN public.phone.description IS 'A free text description providing
 -- Name: program; Type: TABLE; Schema: public; Owner: postgres
 --
 
-CREATE TABLE public.program (
-    id character varying(250) NOT NULL,
+CREATE TABLE public.program
+(
+    id              character varying(250) NOT NULL,
     organization_id character varying(250) NOT NULL,
-    name text NOT NULL,
-    alternate_name text,
-    description text NOT NULL
+    name            text                   NOT NULL,
+    alternate_name  text,
+    description     text                   NOT NULL
 );
 
 
-ALTER TABLE public.program OWNER TO postgres;
+ALTER TABLE public.program
+    OWNER TO postgres;
 
 --
 -- Name: COLUMN program.id; Type: COMMENT; Schema: public; Owner: postgres
@@ -1095,15 +1131,17 @@ COMMENT ON COLUMN public.program.description IS 'A free text description of the 
 -- Name: required_document; Type: TABLE; Schema: public; Owner: postgres
 --
 
-CREATE TABLE public.required_document (
-    id character varying(250) NOT NULL,
+CREATE TABLE public.required_document
+(
+    id         character varying(250) NOT NULL,
     service_id character varying(250),
-    document text,
-    uri text
+    document   text,
+    uri        text
 );
 
 
-ALTER TABLE public.required_document OWNER TO postgres;
+ALTER TABLE public.required_document
+    OWNER TO postgres;
 
 --
 -- Name: COLUMN required_document.id; Type: COMMENT; Schema: public; Owner: postgres
@@ -1137,34 +1175,36 @@ COMMENT ON COLUMN public.required_document.uri IS 'A web link to the document.';
 -- Name: schedule; Type: TABLE; Schema: public; Owner: postgres
 --
 
-CREATE TABLE public.schedule (
-    id character varying(250) NOT NULL,
-    service_id character varying(250),
-    location_id character varying(250),
+CREATE TABLE public.schedule
+(
+    id                     character varying(250) NOT NULL,
+    service_id             character varying(250),
+    location_id            character varying(250),
     service_at_location_id character varying(250),
-    valid_from date,
-    valid_to date,
-    dtstart date,
-    timezone numeric,
-    until date,
-    count numeric,
-    wkst public.schedule_wkst_enum,
-    freq public.schedule_freq_enum,
-    "interval" numeric,
-    byday text,
-    byweekno text,
-    bymonthday text,
-    byyearday text,
-    description text,
-    opens_at time without time zone,
-    closes_at time without time zone,
-    schedule_link text,
-    attending_type text,
-    notes text
+    valid_from             date,
+    valid_to               date,
+    dtstart                date,
+    timezone               numeric,
+    until                  date,
+    count                  numeric,
+    wkst                   public.schedule_wkst_enum,
+    freq                   public.schedule_freq_enum,
+    "interval"             numeric,
+    byday                  text,
+    byweekno               text,
+    bymonthday             text,
+    byyearday              text,
+    description            text,
+    opens_at               time without time zone,
+    closes_at              time without time zone,
+    schedule_link          text,
+    attending_type         text,
+    notes                  text
 );
 
 
-ALTER TABLE public.schedule OWNER TO postgres;
+ALTER TABLE public.schedule
+    OWNER TO postgres;
 
 --
 -- Name: COLUMN schedule.id; Type: COMMENT; Schema: public; Owner: postgres
@@ -1331,34 +1371,36 @@ COMMENT ON COLUMN public.schedule.notes IS 'Free text notes on the schedule.';
 -- Name: service; Type: TABLE; Schema: public; Owner: postgres
 --
 
-CREATE TABLE public.service (
-    id character varying(250) NOT NULL,
-    organization_id character varying(250) NOT NULL,
-    program_id character varying(250),
-    name text NOT NULL,
-    alternate_name text,
-    description text,
-    url text,
-    email text,
-    status public.service_status_enum NOT NULL,
+CREATE TABLE public.service
+(
+    id                      character varying(250)     NOT NULL,
+    organization_id         character varying(250)     NOT NULL,
+    program_id              character varying(250),
+    name                    text                       NOT NULL,
+    alternate_name          text,
+    description             text,
+    url                     text,
+    email                   text,
+    status                  public.service_status_enum NOT NULL,
     interpretation_services text,
-    application_process text,
-    fees_description text,
-    wait_time text,
-    fees text,
-    accreditations text,
+    application_process     text,
+    fees_description        text,
+    wait_time               text,
+    fees                    text,
+    accreditations          text,
     eligibility_description text,
-    minimum_age numeric,
-    maximum_age numeric,
-    assured_date date,
-    assurer_email text,
-    licenses text,
-    alert text,
-    last_modified timestamp without time zone
+    minimum_age             numeric,
+    maximum_age             numeric,
+    assured_date            date,
+    assurer_email           text,
+    licenses                text,
+    alert                   text,
+    last_modified           timestamp without time zone
 );
 
 
-ALTER TABLE public.service OWNER TO postgres;
+ALTER TABLE public.service
+    OWNER TO postgres;
 
 --
 -- Name: COLUMN service.id; Type: COMMENT; Schema: public; Owner: postgres
@@ -1525,18 +1567,21 @@ COMMENT ON COLUMN public.service.last_modified IS 'The datetime when the service
 -- Name: service_area; Type: TABLE; Schema: public; Owner: postgres
 --
 
-CREATE TABLE public.service_area (
-    id character varying(250) NOT NULL,
-    service_id character varying(250),
-    name text,
-    description text,
-    extent text,
-    extent_type text,
-    uri text
+CREATE TABLE public.service_area
+(
+    id                     character varying(250) NOT NULL,
+    service_id             character varying(250),
+    service_at_location_id character varying(250),
+    name                   text,
+    description            text,
+    extent                 text,
+    extent_type            text,
+    uri                    text
 );
 
 
-ALTER TABLE public.service_area OWNER TO postgres;
+ALTER TABLE public.service_area
+    OWNER TO postgres;
 
 --
 -- Name: COLUMN service_area.id; Type: COMMENT; Schema: public; Owner: postgres
@@ -1550,6 +1595,13 @@ COMMENT ON COLUMN public.service_area.id IS 'The identifier for the service area
 --
 
 COMMENT ON COLUMN public.service_area.service_id IS 'The identifier of the service for which this entry describes the service area';
+
+
+--
+-- Name: COLUMN service_area.service_at_location_id; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON COLUMN public.service_area.service_at_location_id IS 'The identifier of the service at location object linked to this object.';
 
 
 --
@@ -1591,15 +1643,17 @@ COMMENT ON COLUMN public.service_area.uri IS 'A URI which acts as a persistent i
 -- Name: service_at_location; Type: TABLE; Schema: public; Owner: postgres
 --
 
-CREATE TABLE public.service_at_location (
-    id character varying(250) NOT NULL,
-    service_id character varying(250) NOT NULL,
+CREATE TABLE public.service_at_location
+(
+    id          character varying(250) NOT NULL,
+    service_id  character varying(250) NOT NULL,
     location_id character varying(250) NOT NULL,
     description text
 );
 
 
-ALTER TABLE public.service_at_location OWNER TO postgres;
+ALTER TABLE public.service_at_location
+    OWNER TO postgres;
 
 --
 -- Name: COLUMN service_at_location.id; Type: COMMENT; Schema: public; Owner: postgres
@@ -1630,19 +1684,89 @@ COMMENT ON COLUMN public.service_at_location.description IS 'A free text descrip
 
 
 --
--- Name: taxonomy; Type: TABLE; Schema: public; Owner: postgres
+-- Name: service_capacity; Type: TABLE; Schema: public; Owner: postgres
 --
 
-CREATE TABLE public.taxonomy (
-    id character varying(250) NOT NULL,
-    name text NOT NULL,
-    description text NOT NULL,
-    uri text,
-    version text
+CREATE TABLE public.service_capacity
+(
+    id          character varying(250)      NOT NULL,
+    service_id  character varying(250)      NOT NULL,
+    unit_id     character varying(250)      NOT NULL,
+    available   numeric                     NOT NULL,
+    maximum     numeric,
+    description text,
+    updated     timestamp without time zone NOT NULL
 );
 
 
-ALTER TABLE public.taxonomy OWNER TO postgres;
+ALTER TABLE public.service_capacity
+    OWNER TO postgres;
+
+--
+-- Name: COLUMN service_capacity.id; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON COLUMN public.service_capacity.id IS 'The identifier for the service_capacity object. Each service_capacity must have a unique identifier.';
+
+
+--
+-- Name: COLUMN service_capacity.service_id; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON COLUMN public.service_capacity.service_id IS 'The identifier for the Service object associated with this service capacity object. Only required in the tabular representation.';
+
+
+--
+-- Name: COLUMN service_capacity.unit_id; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON COLUMN public.service_capacity.unit_id IS 'The identifier for the unit object.';
+
+
+--
+-- Name: COLUMN service_capacity.available; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON COLUMN public.service_capacity.available IS 'The number of units available as of the last update.';
+
+
+--
+-- Name: COLUMN service_capacity.maximum; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON COLUMN public.service_capacity.maximum IS 'The maximum number of units that can be available for this service, if applicable';
+
+
+--
+-- Name: COLUMN service_capacity.description; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON COLUMN public.service_capacity.description IS 'A Human-Friendly description of this service capacity e.g. “Beds available for people experiencing homelessness”';
+
+
+--
+-- Name: COLUMN service_capacity.updated; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON COLUMN public.service_capacity.updated IS 'The datetime when this service_capacit y object was last updated or changed. Should have millisecond accuracy. ';
+
+
+--
+-- Name: taxonomy; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.taxonomy
+(
+    id          character varying(250) NOT NULL,
+    name        text                   NOT NULL,
+    description text                   NOT NULL,
+    uri         text,
+    version     text
+);
+
+
+ALTER TABLE public.taxonomy
+    OWNER TO postgres;
 
 --
 -- Name: COLUMN taxonomy.id; Type: COMMENT; Schema: public; Owner: postgres
@@ -1683,20 +1807,22 @@ COMMENT ON COLUMN public.taxonomy.version IS 'The version of the taxonomy.';
 -- Name: taxonomy_term; Type: TABLE; Schema: public; Owner: postgres
 --
 
-CREATE TABLE public.taxonomy_term (
-    id character varying(250) NOT NULL,
-    code text,
-    name text NOT NULL,
-    description text NOT NULL,
-    parent_id text,
-    taxonomy text,
-    language text,
+CREATE TABLE public.taxonomy_term
+(
+    id          character varying(250) NOT NULL,
+    code        text,
+    name        text                   NOT NULL,
+    description text                   NOT NULL,
+    parent_id   text,
+    taxonomy    text,
+    language    text,
     taxonomy_id character varying(250),
-    term_uri text
+    term_uri    text
 );
 
 
-ALTER TABLE public.taxonomy_term OWNER TO postgres;
+ALTER TABLE public.taxonomy_term
+    OWNER TO postgres;
 
 --
 -- Name: COLUMN taxonomy_term.id; Type: COMMENT; Schema: public; Owner: postgres
@@ -1744,7 +1870,7 @@ COMMENT ON COLUMN public.taxonomy_term.taxonomy IS 'If this is an established ta
 -- Name: COLUMN taxonomy_term.language; Type: COMMENT; Schema: public; Owner: postgres
 --
 
-COMMENT ON COLUMN public.taxonomy_term.language IS 'An ISO 639-1, or ISO 639-2 [language code](available at http://www.loc.gov/standards/iso639-2/php/code_list.php) to represent the language of the term. The three-letter codes from ISO 639-2 provide greater accuracy when describing variants of languages, which may be relevant to particular communities.';
+COMMENT ON COLUMN public.taxonomy_term.language IS 'An ISO 639-1, ISO 639-2, or ISO 639-3 [language code](http://www.loc.gov/standards/iso639-2/php/code_list.php) to represent the language of the term. The three-letter codes from ISO 639-2 and ISO 639-3 provide greater accuracy when describing variants of languages, which may be relevant to particular communities.';
 
 
 --
@@ -1762,19 +1888,73 @@ COMMENT ON COLUMN public.taxonomy_term.term_uri IS 'URI of the term.';
 
 
 --
--- Name: url; Type: TABLE; Schema: public; Owner: postgres
+-- Name: unit; Type: TABLE; Schema: public; Owner: postgres
 --
 
-CREATE TABLE public.url (
-    id character varying(250) NOT NULL,
-    label text,
-    url text NOT NULL,
-    organization_id character varying(250),
-    service_id character varying(250)
+CREATE TABLE public.unit
+(
+    id         character varying(250) NOT NULL,
+    name       text                   NOT NULL,
+    scheme     text,
+    identifier text,
+    uri        text
 );
 
 
-ALTER TABLE public.url OWNER TO postgres;
+ALTER TABLE public.unit
+    OWNER TO postgres;
+
+--
+-- Name: COLUMN unit.id; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON COLUMN public.unit.id IS 'The identifier for the unit object. Each unit must have a unique identifier.';
+
+
+--
+-- Name: COLUMN unit.name; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON COLUMN public.unit.name IS 'The human-readable name for this unit e.g. “Bed” or “Hours”';
+
+
+--
+-- Name: COLUMN unit.scheme; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON COLUMN public.unit.scheme IS 'The scheme which formalizes the unit, if applicable e.g. “SI” for Standard International Units such as Kilogram, Litre, etc.';
+
+
+--
+-- Name: COLUMN unit.identifier; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON COLUMN public.unit.identifier IS 'The identifier of the unit taken from the scheme if applicable e.g. `kgm` for Kilogram.';
+
+
+--
+-- Name: COLUMN unit.uri; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON COLUMN public.unit.uri IS 'The URI to the definition of the unit, if applicable';
+
+
+--
+-- Name: url; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.url
+(
+    id              character varying(250) NOT NULL,
+    label           text,
+    url             text                   NOT NULL,
+    organization_id character varying(250),
+    service_id      character varying(250)
+);
+
+
+ALTER TABLE public.url
+    OWNER TO postgres;
 
 --
 -- Name: COLUMN url.id; Type: COMMENT; Schema: public; Owner: postgres
@@ -1964,6 +2144,14 @@ ALTER TABLE ONLY public.service_at_location
 
 
 --
+-- Name: service_capacity service_capacity_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.service_capacity
+    ADD CONSTRAINT service_capacity_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: service service_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
 --
 
@@ -1996,6 +2184,14 @@ ALTER TABLE ONLY public.taxonomy_term
 
 
 --
+-- Name: unit unit_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.unit
+    ADD CONSTRAINT unit_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: url url_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
 --
 
@@ -2008,7 +2204,7 @@ ALTER TABLE ONLY public.url
 --
 
 ALTER TABLE ONLY public.accessibility
-    ADD CONSTRAINT accessibility_location_id_fkey FOREIGN KEY (location_id) REFERENCES public.location(id);
+    ADD CONSTRAINT accessibility_location_id_fkey FOREIGN KEY (location_id) REFERENCES public.location (id);
 
 
 --
@@ -2016,7 +2212,7 @@ ALTER TABLE ONLY public.accessibility
 --
 
 ALTER TABLE ONLY public.address
-    ADD CONSTRAINT address_location_id_fkey FOREIGN KEY (location_id) REFERENCES public.location(id);
+    ADD CONSTRAINT address_location_id_fkey FOREIGN KEY (location_id) REFERENCES public.location (id);
 
 
 --
@@ -2024,7 +2220,7 @@ ALTER TABLE ONLY public.address
 --
 
 ALTER TABLE ONLY public.attribute
-    ADD CONSTRAINT attribute_taxonomy_term_id_fkey FOREIGN KEY (taxonomy_term_id) REFERENCES public.taxonomy_term(id);
+    ADD CONSTRAINT attribute_taxonomy_term_id_fkey FOREIGN KEY (taxonomy_term_id) REFERENCES public.taxonomy_term (id);
 
 
 --
@@ -2032,7 +2228,7 @@ ALTER TABLE ONLY public.attribute
 --
 
 ALTER TABLE ONLY public.contact
-    ADD CONSTRAINT contact_location_id_fkey FOREIGN KEY (location_id) REFERENCES public.location(id);
+    ADD CONSTRAINT contact_location_id_fkey FOREIGN KEY (location_id) REFERENCES public.location (id);
 
 
 --
@@ -2040,7 +2236,7 @@ ALTER TABLE ONLY public.contact
 --
 
 ALTER TABLE ONLY public.contact
-    ADD CONSTRAINT contact_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES public.organization(id);
+    ADD CONSTRAINT contact_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES public.organization (id);
 
 
 --
@@ -2048,7 +2244,7 @@ ALTER TABLE ONLY public.contact
 --
 
 ALTER TABLE ONLY public.contact
-    ADD CONSTRAINT contact_service_at_location_id_fkey FOREIGN KEY (service_at_location_id) REFERENCES public.service_at_location(id);
+    ADD CONSTRAINT contact_service_at_location_id_fkey FOREIGN KEY (service_at_location_id) REFERENCES public.service_at_location (id);
 
 
 --
@@ -2056,7 +2252,7 @@ ALTER TABLE ONLY public.contact
 --
 
 ALTER TABLE ONLY public.contact
-    ADD CONSTRAINT contact_service_id_fkey FOREIGN KEY (service_id) REFERENCES public.service(id);
+    ADD CONSTRAINT contact_service_id_fkey FOREIGN KEY (service_id) REFERENCES public.service (id);
 
 
 --
@@ -2064,7 +2260,7 @@ ALTER TABLE ONLY public.contact
 --
 
 ALTER TABLE ONLY public.cost_option
-    ADD CONSTRAINT cost_option_service_id_fkey FOREIGN KEY (service_id) REFERENCES public.service(id);
+    ADD CONSTRAINT cost_option_service_id_fkey FOREIGN KEY (service_id) REFERENCES public.service (id);
 
 
 --
@@ -2072,7 +2268,7 @@ ALTER TABLE ONLY public.cost_option
 --
 
 ALTER TABLE ONLY public.funding
-    ADD CONSTRAINT funding_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES public.organization(id);
+    ADD CONSTRAINT funding_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES public.organization (id);
 
 
 --
@@ -2080,7 +2276,7 @@ ALTER TABLE ONLY public.funding
 --
 
 ALTER TABLE ONLY public.funding
-    ADD CONSTRAINT funding_service_id_fkey FOREIGN KEY (service_id) REFERENCES public.service(id);
+    ADD CONSTRAINT funding_service_id_fkey FOREIGN KEY (service_id) REFERENCES public.service (id);
 
 
 --
@@ -2088,7 +2284,7 @@ ALTER TABLE ONLY public.funding
 --
 
 ALTER TABLE ONLY public.language
-    ADD CONSTRAINT language_location_id_fkey FOREIGN KEY (location_id) REFERENCES public.location(id);
+    ADD CONSTRAINT language_location_id_fkey FOREIGN KEY (location_id) REFERENCES public.location (id);
 
 
 --
@@ -2096,7 +2292,7 @@ ALTER TABLE ONLY public.language
 --
 
 ALTER TABLE ONLY public.language
-    ADD CONSTRAINT language_phone_id_fkey FOREIGN KEY (phone_id) REFERENCES public.phone(id);
+    ADD CONSTRAINT language_phone_id_fkey FOREIGN KEY (phone_id) REFERENCES public.phone (id);
 
 
 --
@@ -2104,7 +2300,7 @@ ALTER TABLE ONLY public.language
 --
 
 ALTER TABLE ONLY public.language
-    ADD CONSTRAINT language_service_id_fkey FOREIGN KEY (service_id) REFERENCES public.service(id);
+    ADD CONSTRAINT language_service_id_fkey FOREIGN KEY (service_id) REFERENCES public.service (id);
 
 
 --
@@ -2112,7 +2308,7 @@ ALTER TABLE ONLY public.language
 --
 
 ALTER TABLE ONLY public.location
-    ADD CONSTRAINT location_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES public.organization(id);
+    ADD CONSTRAINT location_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES public.organization (id);
 
 
 --
@@ -2120,7 +2316,7 @@ ALTER TABLE ONLY public.location
 --
 
 ALTER TABLE ONLY public.organization_identifier
-    ADD CONSTRAINT organization_identifier_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES public.organization(id);
+    ADD CONSTRAINT organization_identifier_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES public.organization (id);
 
 
 --
@@ -2128,7 +2324,7 @@ ALTER TABLE ONLY public.organization_identifier
 --
 
 ALTER TABLE ONLY public.phone
-    ADD CONSTRAINT phone_contact_id_fkey FOREIGN KEY (contact_id) REFERENCES public.contact(id);
+    ADD CONSTRAINT phone_contact_id_fkey FOREIGN KEY (contact_id) REFERENCES public.contact (id);
 
 
 --
@@ -2136,7 +2332,7 @@ ALTER TABLE ONLY public.phone
 --
 
 ALTER TABLE ONLY public.phone
-    ADD CONSTRAINT phone_location_id_fkey FOREIGN KEY (location_id) REFERENCES public.location(id);
+    ADD CONSTRAINT phone_location_id_fkey FOREIGN KEY (location_id) REFERENCES public.location (id);
 
 
 --
@@ -2144,7 +2340,7 @@ ALTER TABLE ONLY public.phone
 --
 
 ALTER TABLE ONLY public.phone
-    ADD CONSTRAINT phone_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES public.organization(id);
+    ADD CONSTRAINT phone_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES public.organization (id);
 
 
 --
@@ -2152,7 +2348,7 @@ ALTER TABLE ONLY public.phone
 --
 
 ALTER TABLE ONLY public.phone
-    ADD CONSTRAINT phone_service_at_location_id_fkey FOREIGN KEY (service_at_location_id) REFERENCES public.service_at_location(id);
+    ADD CONSTRAINT phone_service_at_location_id_fkey FOREIGN KEY (service_at_location_id) REFERENCES public.service_at_location (id);
 
 
 --
@@ -2160,7 +2356,7 @@ ALTER TABLE ONLY public.phone
 --
 
 ALTER TABLE ONLY public.phone
-    ADD CONSTRAINT phone_service_id_fkey FOREIGN KEY (service_id) REFERENCES public.service(id);
+    ADD CONSTRAINT phone_service_id_fkey FOREIGN KEY (service_id) REFERENCES public.service (id);
 
 
 --
@@ -2168,7 +2364,7 @@ ALTER TABLE ONLY public.phone
 --
 
 ALTER TABLE ONLY public.program
-    ADD CONSTRAINT program_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES public.organization(id);
+    ADD CONSTRAINT program_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES public.organization (id);
 
 
 --
@@ -2176,7 +2372,7 @@ ALTER TABLE ONLY public.program
 --
 
 ALTER TABLE ONLY public.required_document
-    ADD CONSTRAINT required_document_service_id_fkey FOREIGN KEY (service_id) REFERENCES public.service(id);
+    ADD CONSTRAINT required_document_service_id_fkey FOREIGN KEY (service_id) REFERENCES public.service (id);
 
 
 --
@@ -2184,7 +2380,7 @@ ALTER TABLE ONLY public.required_document
 --
 
 ALTER TABLE ONLY public.schedule
-    ADD CONSTRAINT schedule_location_id_fkey FOREIGN KEY (location_id) REFERENCES public.location(id);
+    ADD CONSTRAINT schedule_location_id_fkey FOREIGN KEY (location_id) REFERENCES public.location (id);
 
 
 --
@@ -2192,7 +2388,7 @@ ALTER TABLE ONLY public.schedule
 --
 
 ALTER TABLE ONLY public.schedule
-    ADD CONSTRAINT schedule_service_at_location_id_fkey FOREIGN KEY (service_at_location_id) REFERENCES public.service_at_location(id);
+    ADD CONSTRAINT schedule_service_at_location_id_fkey FOREIGN KEY (service_at_location_id) REFERENCES public.service_at_location (id);
 
 
 --
@@ -2200,7 +2396,15 @@ ALTER TABLE ONLY public.schedule
 --
 
 ALTER TABLE ONLY public.schedule
-    ADD CONSTRAINT schedule_service_id_fkey FOREIGN KEY (service_id) REFERENCES public.service(id);
+    ADD CONSTRAINT schedule_service_id_fkey FOREIGN KEY (service_id) REFERENCES public.service (id);
+
+
+--
+-- Name: service_area service_area_service_at_location_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.service_area
+    ADD CONSTRAINT service_area_service_at_location_id_fkey FOREIGN KEY (service_at_location_id) REFERENCES public.service_at_location (id);
 
 
 --
@@ -2208,7 +2412,7 @@ ALTER TABLE ONLY public.schedule
 --
 
 ALTER TABLE ONLY public.service_area
-    ADD CONSTRAINT service_area_service_id_fkey FOREIGN KEY (service_id) REFERENCES public.service(id);
+    ADD CONSTRAINT service_area_service_id_fkey FOREIGN KEY (service_id) REFERENCES public.service (id);
 
 
 --
@@ -2216,7 +2420,7 @@ ALTER TABLE ONLY public.service_area
 --
 
 ALTER TABLE ONLY public.service_at_location
-    ADD CONSTRAINT service_at_location_location_id_fkey FOREIGN KEY (location_id) REFERENCES public.location(id);
+    ADD CONSTRAINT service_at_location_location_id_fkey FOREIGN KEY (location_id) REFERENCES public.location (id);
 
 
 --
@@ -2224,7 +2428,23 @@ ALTER TABLE ONLY public.service_at_location
 --
 
 ALTER TABLE ONLY public.service_at_location
-    ADD CONSTRAINT service_at_location_service_id_fkey FOREIGN KEY (service_id) REFERENCES public.service(id);
+    ADD CONSTRAINT service_at_location_service_id_fkey FOREIGN KEY (service_id) REFERENCES public.service (id);
+
+
+--
+-- Name: service_capacity service_capacity_service_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.service_capacity
+    ADD CONSTRAINT service_capacity_service_id_fkey FOREIGN KEY (service_id) REFERENCES public.service (id);
+
+
+--
+-- Name: service_capacity service_capacity_unit_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.service_capacity
+    ADD CONSTRAINT service_capacity_unit_id_fkey FOREIGN KEY (unit_id) REFERENCES public.unit (id);
 
 
 --
@@ -2232,7 +2452,7 @@ ALTER TABLE ONLY public.service_at_location
 --
 
 ALTER TABLE ONLY public.service
-    ADD CONSTRAINT service_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES public.organization(id);
+    ADD CONSTRAINT service_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES public.organization (id);
 
 
 --
@@ -2240,7 +2460,7 @@ ALTER TABLE ONLY public.service
 --
 
 ALTER TABLE ONLY public.service
-    ADD CONSTRAINT service_program_id_fkey FOREIGN KEY (program_id) REFERENCES public.program(id);
+    ADD CONSTRAINT service_program_id_fkey FOREIGN KEY (program_id) REFERENCES public.program (id);
 
 
 --
@@ -2248,7 +2468,7 @@ ALTER TABLE ONLY public.service
 --
 
 ALTER TABLE ONLY public.taxonomy_term
-    ADD CONSTRAINT taxonomy_term_taxonomy_id_fkey FOREIGN KEY (taxonomy_id) REFERENCES public.taxonomy(id);
+    ADD CONSTRAINT taxonomy_term_taxonomy_id_fkey FOREIGN KEY (taxonomy_id) REFERENCES public.taxonomy (id);
 
 
 --
@@ -2256,7 +2476,7 @@ ALTER TABLE ONLY public.taxonomy_term
 --
 
 ALTER TABLE ONLY public.url
-    ADD CONSTRAINT url_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES public.organization(id);
+    ADD CONSTRAINT url_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES public.organization (id);
 
 
 --
@@ -2264,10 +2484,9 @@ ALTER TABLE ONLY public.url
 --
 
 ALTER TABLE ONLY public.url
-    ADD CONSTRAINT url_service_id_fkey FOREIGN KEY (service_id) REFERENCES public.service(id);
+    ADD CONSTRAINT url_service_id_fkey FOREIGN KEY (service_id) REFERENCES public.service (id);
 
 
 --
 -- PostgreSQL database dump complete
 --
-

--- a/src/main/java/com/sarapis/orservice/OrserviceApplication.java
+++ b/src/main/java/com/sarapis/orservice/OrserviceApplication.java
@@ -4,9 +4,9 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 
-@SpringBootApplication(exclude = {SecurityAutoConfiguration.class})
+@SpringBootApplication(exclude = { SecurityAutoConfiguration.class })
 public class OrserviceApplication {
-	public static void main(String[] args) {
-		SpringApplication.run(OrserviceApplication.class, args);
-	}
+    public static void main(String[] args) {
+        SpringApplication.run(OrserviceApplication.class, args);
+    }
 }

--- a/src/main/java/com/sarapis/orservice/config/SecurityConfig.java
+++ b/src/main/java/com/sarapis/orservice/config/SecurityConfig.java
@@ -1,6 +1,5 @@
 package com.sarapis.orservice.config;
 
-import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
@@ -12,22 +11,29 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
+import java.util.List;
+
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig {
     private static final List<String> ALLOWED_ORIGINS_DEV = List.of("http://localhost:5173/");
-    private static final List<String> ALLOWED_ORIGINS_PROD = List
-            .of("http://ec2-34-229-138-80.compute-1.amazonaws.com/");
+    private static final List<String> ALLOWED_ORIGINS_PROD = List.of("http://ec2-34-229-138-80.compute-1.amazonaws.com/");
 
     @Bean
     @Profile("prod")
     public SecurityFilterChain prodSecurityFilterChain(HttpSecurity http) throws Exception {
         return http
-                .authorizeHttpRequests(authorize -> authorize.requestMatchers("/actuator/**").permitAll()
-                        .requestMatchers("/").permitAll().anyRequest().authenticated())
+                .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers("/actuator/**")
+                        .permitAll()
+                        .requestMatchers("/")
+                        .permitAll()
+                        .anyRequest()
+                        .authenticated())
                 .cors(httpSecurityCorsConfigurer -> httpSecurityCorsConfigurer
                         .configurationSource(corsConfigurationSource(ALLOWED_ORIGINS_PROD)))
-                .csrf(AbstractHttpConfigurer::disable).build();
+                .csrf(AbstractHttpConfigurer::disable)
+                .build();
     }
 
     @Bean
@@ -36,7 +42,10 @@ public class SecurityConfig {
         return http.csrf(AbstractHttpConfigurer::disable)
                 .cors(httpSecurityCorsConfigurer -> httpSecurityCorsConfigurer
                         .configurationSource(corsConfigurationSource(ALLOWED_ORIGINS_DEV)))
-                .authorizeHttpRequests(authorize -> authorize.requestMatchers("/**").permitAll()).build();
+                .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers("/**")
+                        .permitAll())
+                .build();
     }
 
     @Bean

--- a/src/main/java/com/sarapis/orservice/config/SecurityConfig.java
+++ b/src/main/java/com/sarapis/orservice/config/SecurityConfig.java
@@ -15,45 +15,40 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig {
-  private static final List<String> ALLOWED_ORIGINS_DEV = List.of("http://localhost:5173/");
-  private static final List<String> ALLOWED_ORIGINS_PROD = List.of(" http://ec2-34-229-138-80.compute-1.amazonaws.com/");
+    private static final List<String> ALLOWED_ORIGINS_DEV = List.of("http://localhost:5173/");
+    private static final List<String> ALLOWED_ORIGINS_PROD = List
+            .of("http://ec2-34-229-138-80.compute-1.amazonaws.com/");
 
-  @Bean
-  @Profile("prod")
-  public SecurityFilterChain prodSecurityFilterChain(HttpSecurity http) throws Exception {
-    return http
-        .authorizeHttpRequests(authorize ->
-            authorize
-                .requestMatchers("/actuator/**").permitAll()
-                .requestMatchers("/").permitAll()
-                .anyRequest().authenticated())
-        .cors(httpSecurityCorsConfigurer -> httpSecurityCorsConfigurer.configurationSource(corsConfigurationSource(ALLOWED_ORIGINS_PROD)))
-        .csrf(AbstractHttpConfigurer::disable).build();
-  }
+    @Bean
+    @Profile("prod")
+    public SecurityFilterChain prodSecurityFilterChain(HttpSecurity http) throws Exception {
+        return http
+                .authorizeHttpRequests(authorize -> authorize.requestMatchers("/actuator/**").permitAll()
+                        .requestMatchers("/").permitAll().anyRequest().authenticated())
+                .cors(httpSecurityCorsConfigurer -> httpSecurityCorsConfigurer
+                        .configurationSource(corsConfigurationSource(ALLOWED_ORIGINS_PROD)))
+                .csrf(AbstractHttpConfigurer::disable).build();
+    }
 
-  @Bean
-  @Profile("dev")
-  public SecurityFilterChain devSecurityFilterChain(HttpSecurity http) throws Exception {
-    return http
-        .csrf(AbstractHttpConfigurer::disable)
-        .cors(httpSecurityCorsConfigurer -> httpSecurityCorsConfigurer
-            .configurationSource(corsConfigurationSource(ALLOWED_ORIGINS_DEV)))
-        .authorizeHttpRequests(authorize ->
-        authorize
-            .requestMatchers("/**").permitAll()
-    ).build();
-  }
+    @Bean
+    @Profile("dev")
+    public SecurityFilterChain devSecurityFilterChain(HttpSecurity http) throws Exception {
+        return http.csrf(AbstractHttpConfigurer::disable)
+                .cors(httpSecurityCorsConfigurer -> httpSecurityCorsConfigurer
+                        .configurationSource(corsConfigurationSource(ALLOWED_ORIGINS_DEV)))
+                .authorizeHttpRequests(authorize -> authorize.requestMatchers("/**").permitAll()).build();
+    }
 
-  @Bean
-  public CorsConfigurationSource corsConfigurationSource(List<String> allowedOrigins) {
-    CorsConfiguration corsConfiguration = new CorsConfiguration();
-    corsConfiguration.setAllowedOrigins(allowedOrigins);
-    corsConfiguration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE"));
-    corsConfiguration.setAllowCredentials(true);
-    corsConfiguration.setAllowedHeaders(List.of("*"));
-    corsConfiguration.setMaxAge(3600L);
-    UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-    source.registerCorsConfiguration("/**", corsConfiguration);
-    return source;
-  }
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource(List<String> allowedOrigins) {
+        CorsConfiguration corsConfiguration = new CorsConfiguration();
+        corsConfiguration.setAllowedOrigins(allowedOrigins);
+        corsConfiguration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE"));
+        corsConfiguration.setAllowCredentials(true);
+        corsConfiguration.setAllowedHeaders(List.of("*"));
+        corsConfiguration.setMaxAge(3600L);
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", corsConfiguration);
+        return source;
+    }
 }

--- a/src/main/java/com/sarapis/orservice/controller/AccessibilityController.java
+++ b/src/main/java/com/sarapis/orservice/controller/AccessibilityController.java
@@ -7,7 +7,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
-import java.util.UUID;
 
 @RestController
 @RequestMapping("/api/accessibilities")
@@ -21,34 +20,33 @@ public class AccessibilityController {
 
     @GetMapping
     public ResponseEntity<List<AccessibilityDTO>> getAllAccessibilities() {
-        List<AccessibilityDTO> accessibilityDTOs = this.accessibilityService.getAllAccessibilities();
-        return ResponseEntity.ok(accessibilityDTOs);
+        List<AccessibilityDTO> accessibilities = this.accessibilityService.getAllAccessibilities();
+        return ResponseEntity.ok(accessibilities);
     }
 
-    @GetMapping("/{id}")
-    public ResponseEntity<AccessibilityDTO> getAccessibilityById(@PathVariable String id) {
-        AccessibilityDTO accessibility = this.accessibilityService.getAccessibilityById(id);
+    @GetMapping("/{accessibilityId}")
+    public ResponseEntity<AccessibilityDTO> getAccessibilityById(@PathVariable String accessibilityId) {
+        AccessibilityDTO accessibility = this.accessibilityService.getAccessibilityById(accessibilityId);
         return ResponseEntity.ok(accessibility);
     }
 
     @PostMapping
     public ResponseEntity<AccessibilityDTO> createAccessibility(@RequestBody AccessibilityDTO accessibilityDTO) {
-        if (accessibilityDTO.getId() == null) {
-            accessibilityDTO.setId(UUID.randomUUID().toString());
-        }
         AccessibilityDTO createdAccessibility = this.accessibilityService.createAccessibility(accessibilityDTO);
         return ResponseEntity.ok(createdAccessibility);
     }
 
-    @PutMapping("/{id}")
-    public ResponseEntity<AccessibilityDTO> updateAccessibility(@PathVariable String id, @RequestBody AccessibilityDTO accessibilityDTO) {
-        AccessibilityDTO updatedAccessibility = this.accessibilityService.updateAccessibility(id, accessibilityDTO);
+    @PutMapping("/{accessibilityId}")
+    public ResponseEntity<AccessibilityDTO> updateAccessibility(@PathVariable String accessibilityId,
+                                                                @RequestBody AccessibilityDTO accessibilityDTO) {
+        AccessibilityDTO updatedAccessibility = this.accessibilityService
+                .updateAccessibility(accessibilityId, accessibilityDTO);
         return ResponseEntity.ok(updatedAccessibility);
     }
 
-    @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deleteAccessibility(@PathVariable String id) {
-        this.accessibilityService.deleteAccessibility(id);
+    @DeleteMapping("/{accessibilityId}")
+    public ResponseEntity<Void> deleteAccessibility(@PathVariable String accessibilityId) {
+        this.accessibilityService.deleteAccessibility(accessibilityId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/sarapis/orservice/controller/AddressController.java
+++ b/src/main/java/com/sarapis/orservice/controller/AddressController.java
@@ -20,14 +20,14 @@ public class AddressController {
 
     @GetMapping
     public ResponseEntity<List<AddressDTO>> getAllAddresses() {
-        List<AddressDTO> addressDTOs = this.addressService.getAllAddresses();
-        return ResponseEntity.ok(addressDTOs);
+        List<AddressDTO> addresses = this.addressService.getAllAddresses();
+        return ResponseEntity.ok(addresses);
     }
 
-    @GetMapping("/{id}")
-    public ResponseEntity<AddressDTO> getAddressById(@PathVariable String id) {
-        AddressDTO queried = this.addressService.getAddressById(id);
-        return ResponseEntity.ok(queried);
+    @GetMapping("/{addressId}")
+    public ResponseEntity<AddressDTO> getAddressById(@PathVariable String addressId) {
+        AddressDTO address = this.addressService.getAddressById(addressId);
+        return ResponseEntity.ok(address);
     }
 
     @PostMapping
@@ -36,15 +36,16 @@ public class AddressController {
         return ResponseEntity.ok(createdAddress);
     }
 
-    @PutMapping("/{id}")
-    public ResponseEntity<AddressDTO> updateAddress(@PathVariable String id, @RequestBody AddressDTO addressDTO) {
-        AddressDTO updateAddress = this.addressService.updateAddress(id, addressDTO);
-        return ResponseEntity.ok(updateAddress);
+    @PutMapping("/{addressId}")
+    public ResponseEntity<AddressDTO> updateAddress(@PathVariable String addressId,
+                                                    @RequestBody AddressDTO addressDTO) {
+        AddressDTO updatedAddress = this.addressService.updateAddress(addressId, addressDTO);
+        return ResponseEntity.ok(updatedAddress);
     }
 
-    @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deleteAddress(@PathVariable String id) {
-        this.addressService.deleteAddress(id);
+    @DeleteMapping("/{addressId}")
+    public ResponseEntity<Void> deleteAddress(@PathVariable String addressId) {
+        this.addressService.deleteAddress(addressId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/sarapis/orservice/controller/AttributeController.java
+++ b/src/main/java/com/sarapis/orservice/controller/AttributeController.java
@@ -20,31 +20,32 @@ public class AttributeController {
 
     @GetMapping
     public ResponseEntity<List<AttributeDTO>> getAllAttributes() {
-        List<AttributeDTO> attributeDTOs = this.attributeService.getAllAttributes();
-        return ResponseEntity.ok(attributeDTOs);
+        List<AttributeDTO> attributes = this.attributeService.getAllAttributes();
+        return ResponseEntity.ok(attributes);
     }
 
-    @GetMapping("/{id}")
-    public ResponseEntity<AttributeDTO> getAttributeById(@PathVariable String id) {
-        AttributeDTO queried = this.attributeService.getAttributeById(id);
-        return ResponseEntity.ok(queried);
+    @GetMapping("/{attributeId}")
+    public ResponseEntity<AttributeDTO> getAttributeById(@PathVariable String attributeId) {
+        AttributeDTO attribute = this.attributeService.getAttributeById(attributeId);
+        return ResponseEntity.ok(attribute);
     }
 
     @PostMapping
     public ResponseEntity<AttributeDTO> createAttribute(@RequestBody AttributeDTO attributeDTO) {
-        AttributeDTO createdAttribute = this.attributeService.createAttribute(attributeDTO);
+        AttributeDTO createdAttribute = this.attributeService.createAttribute(attributeDTO.getLinkId(), attributeDTO);
         return ResponseEntity.ok(createdAttribute);
     }
 
-    @PutMapping("/{id}")
-    public ResponseEntity<AttributeDTO> updateAttribute(@PathVariable String id, @RequestBody AttributeDTO attributeDTO) {
-        AttributeDTO updatedAttribute = this.attributeService.updateAttribute(id, attributeDTO);
+    @PutMapping("/{attributeId}")
+    public ResponseEntity<AttributeDTO> updateAttribute(@PathVariable String attributeId,
+                                                        @RequestBody AttributeDTO attributeDTO) {
+        AttributeDTO updatedAttribute = this.attributeService.updateAttribute(attributeId, attributeDTO);
         return ResponseEntity.ok(updatedAttribute);
     }
 
-    @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deleteAttribute(@PathVariable String id) {
-        this.attributeService.deleteAttribute(id);
+    @DeleteMapping("/{attributeId}")
+    public ResponseEntity<Void> deleteAttribute(@PathVariable String attributeId) {
+        this.attributeService.deleteAttribute(attributeId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/sarapis/orservice/controller/BaseController.java
+++ b/src/main/java/com/sarapis/orservice/controller/BaseController.java
@@ -9,13 +9,13 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/")
 public class BaseController {
-  @GetMapping
-  public ResponseEntity<RootDTO> getRoot() {
-    RootDTO root = RootDTO.builder()
-        .version("3.0")
-        .profile("https://docs.openreferraluk.org/en/latest/")
-        .openapiUrl("https://raw.githubusercontent.com/openreferral/specification/3.0/schema/openapi.json")
-        .build();
-    return ResponseEntity.ok(root);
-  }
+    @GetMapping
+    public ResponseEntity<RootDTO> getRoot() {
+        RootDTO root = RootDTO.builder()
+                .version("3.0")
+                .profile("https://docs.openreferraluk.org/en/latest/")
+                .openapiUrl("https://raw.githubusercontent.com/openreferral/specification/3.0/schema/openapi.json")
+                .build();
+        return ResponseEntity.ok(root);
+    }
 }

--- a/src/main/java/com/sarapis/orservice/controller/ContactController.java
+++ b/src/main/java/com/sarapis/orservice/controller/ContactController.java
@@ -7,7 +7,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
-import java.util.UUID;
 
 @RestController
 @RequestMapping("/api/contacts")
@@ -21,34 +20,32 @@ public class ContactController {
 
     @GetMapping
     public ResponseEntity<List<ContactDTO>> getAllContacts() {
-        List<ContactDTO> contactDTOs = this.contactService.getAllContacts();
-        return ResponseEntity.ok(contactDTOs);
+        List<ContactDTO> contacts = this.contactService.getAllContacts();
+        return ResponseEntity.ok(contacts);
     }
 
-    @GetMapping("/{id}")
-    public ResponseEntity<ContactDTO> getContactById(@PathVariable String id) {
-        ContactDTO contactDTO = this.contactService.getContactById(id);
-        return ResponseEntity.ok(contactDTO);
+    @GetMapping("/{contactId}")
+    public ResponseEntity<ContactDTO> getContactById(@PathVariable String contactId) {
+        ContactDTO contact = this.contactService.getContactById(contactId);
+        return ResponseEntity.ok(contact);
     }
 
     @PostMapping
     public ResponseEntity<ContactDTO> createContact(@RequestBody ContactDTO contactDTO) {
-        if (contactDTO.getId() == null) {
-            contactDTO.setId(UUID.randomUUID().toString());
-        }
         ContactDTO createdContact = this.contactService.createContact(contactDTO);
         return ResponseEntity.ok(createdContact);
     }
 
-    @PutMapping("/{id}")
-    public ResponseEntity<ContactDTO> updateContact(@PathVariable String id, @RequestBody ContactDTO contactDTO) {
-        ContactDTO updatedAccessibility = this.contactService.updateContact(id, contactDTO);
-        return ResponseEntity.ok(updatedAccessibility);
+    @PutMapping("/{contactId}")
+    public ResponseEntity<ContactDTO> updateContact(@PathVariable String contactId,
+                                                    @RequestBody ContactDTO contactDTO) {
+        ContactDTO updatedContact = this.contactService.updateContact(contactId, contactDTO);
+        return ResponseEntity.ok(updatedContact);
     }
 
-    @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deleteContact(@PathVariable String id) {
-        this.contactService.deleteContact(id);
+    @DeleteMapping("/{contactId}")
+    public ResponseEntity<Void> deleteContact(@PathVariable String contactId) {
+        this.contactService.deleteContact(contactId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/sarapis/orservice/controller/ExportController.java
+++ b/src/main/java/com/sarapis/orservice/controller/ExportController.java
@@ -1,7 +1,6 @@
 package com.sarapis.orservice.controller;
 
 import com.sarapis.orservice.service.OrganizationService;
-import java.io.ByteArrayInputStream;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.InputStreamResource;
 import org.springframework.core.io.Resource;
@@ -12,19 +11,17 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/export")
 public class ExportController {
-  private final OrganizationService organizationService;
+    private final OrganizationService organizationService;
 
-  @Autowired
-  public ExportController(OrganizationService organizationService) {
-    this.organizationService = organizationService;
-  }
+    @Autowired
+    public ExportController(OrganizationService organizationService) {
+        this.organizationService = organizationService;
+    }
 
-  @RequestMapping("/csv")
-  public ResponseEntity<Resource> exportCSV() {
-    String filename = "organizations.csv";
-    InputStreamResource organizationCSV =  new InputStreamResource(organizationService.loadCSV());
-    return ResponseEntity.ok()
-        .body(organizationCSV);
-  }
-
+    @RequestMapping("/csv")
+    public ResponseEntity<Resource> exportCSV() {
+        String filename = "organizations.csv";
+        InputStreamResource organizationCSV = new InputStreamResource(organizationService.loadCSV());
+        return ResponseEntity.ok().body(organizationCSV);
+    }
 }

--- a/src/main/java/com/sarapis/orservice/controller/ImportController.java
+++ b/src/main/java/com/sarapis/orservice/controller/ImportController.java
@@ -8,21 +8,19 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/import")
 public class ImportController {
-  @GetMapping("/csv")
-  public void exportCSV() {
-  }
+    @GetMapping("/csv")
+    public void exportCSV() {
+    }
 
-  @PostMapping("/csv")
-  public void importCSV() {
-  }
+    @PostMapping("/csv")
+    public void importCSV() {
+    }
 
-  @GetMapping("/pdf")
-  public void exportPDF() {
+    @GetMapping("/pdf")
+    public void exportPDF() {
+    }
 
-  }
-
-  @PostMapping("/pdf")
-  public void importPDF() {
-
-  }
+    @PostMapping("/pdf")
+    public void importPDF() {
+    }
 }

--- a/src/main/java/com/sarapis/orservice/controller/LanguageController.java
+++ b/src/main/java/com/sarapis/orservice/controller/LanguageController.java
@@ -20,31 +20,32 @@ public class LanguageController {
 
     @GetMapping
     public ResponseEntity<List<LanguageDTO>> getAllLanguages() {
-        List<LanguageDTO> languageDTOs = this.languageService.getAllLanguages();
-        return ResponseEntity.ok(languageDTOs);
+        List<LanguageDTO> languages = this.languageService.getAllLanguages();
+        return ResponseEntity.ok(languages);
     }
 
-    @GetMapping("/{id}")
-    public ResponseEntity<LanguageDTO> getLanguageById(@PathVariable String id) {
-        LanguageDTO languageDTO = this.languageService.getLanguageById(id);
-        return ResponseEntity.ok(languageDTO);
+    @GetMapping("/{languageId}")
+    public ResponseEntity<LanguageDTO> getLanguageById(@PathVariable String languageId) {
+        LanguageDTO language = this.languageService.getLanguageById(languageId);
+        return ResponseEntity.ok(language);
     }
 
     @PostMapping
     public ResponseEntity<LanguageDTO> createLanguage(@RequestBody LanguageDTO languageDTO) {
-        LanguageDTO createdLanguageDTO = this.languageService.createLanguage(languageDTO);
-        return ResponseEntity.ok(createdLanguageDTO);
+        LanguageDTO createdLanguage = this.languageService.createLanguage(languageDTO);
+        return ResponseEntity.ok(createdLanguage);
     }
 
-    @PutMapping("/{id}")
-    public ResponseEntity<LanguageDTO> updateLanguage(@PathVariable String id, @RequestBody LanguageDTO languageDTO) {
-        LanguageDTO updatedLanguageDTO = this.languageService.updateLanguage(id, languageDTO);
-        return ResponseEntity.ok(updatedLanguageDTO);
+    @PutMapping("/{languageId}")
+    public ResponseEntity<LanguageDTO> updateLanguage(@PathVariable String languageId,
+                                                      @RequestBody LanguageDTO languageDTO) {
+        LanguageDTO updatedLanguage = this.languageService.updateLanguage(languageId, languageDTO);
+        return ResponseEntity.ok(updatedLanguage);
     }
 
-    @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deleteLanguage(@PathVariable String id) {
-        this.languageService.deleteLanguage(id);
+    @DeleteMapping("/{languageId}")
+    public ResponseEntity<Void> deleteLanguage(@PathVariable String languageId) {
+        this.languageService.deleteLanguage(languageId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/sarapis/orservice/controller/LocationController.java
+++ b/src/main/java/com/sarapis/orservice/controller/LocationController.java
@@ -1,0 +1,62 @@
+package com.sarapis.orservice.controller;
+
+import com.sarapis.orservice.dto.LocationDTO;
+import com.sarapis.orservice.dto.PaginationDTO;
+import com.sarapis.orservice.service.LocationService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/locations")
+public class LocationController {
+    private final LocationService locationService;
+
+    @Autowired
+    public LocationController(LocationService locationService) {
+        this.locationService = locationService;
+    }
+
+    @GetMapping
+    public ResponseEntity<PaginationDTO<LocationDTO>> getAllLocations() {
+        List<LocationDTO> locations = this.locationService.getAllLocations();
+        PaginationDTO<LocationDTO> pagination = PaginationDTO.of(
+                locations.size(),
+                1,
+                1,
+                locations.size(),
+                true,
+                false,
+                false,
+                locations
+        );
+        return ResponseEntity.ok(pagination);
+    }
+
+    @GetMapping("/{locationId}")
+    public ResponseEntity<LocationDTO> getLocation(@PathVariable String locationId) {
+        LocationDTO location = this.locationService.getLocation(locationId);
+        return ResponseEntity.ok(location);
+    }
+
+    @PostMapping
+    public ResponseEntity<LocationDTO> createLocation(@RequestBody LocationDTO locationDTO) {
+        LocationDTO createdLocation = this.locationService.createLocation(locationDTO);
+        return ResponseEntity.ok(createdLocation);
+    }
+
+    @PutMapping("/{locationId}")
+    public ResponseEntity<LocationDTO> updateLocation(@PathVariable String locationId,
+                                                      @RequestBody LocationDTO locationDTO) {
+        LocationDTO updatedLocation = this.locationService.updateLocation(locationId, locationDTO);
+        return ResponseEntity.ok(updatedLocation);
+    }
+
+    @DeleteMapping("/{locationId}")
+    public ResponseEntity<Void> deleteLocation(@PathVariable String locationId) {
+        this.locationService.deleteLocation(locationId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/sarapis/orservice/controller/LocationController.java
+++ b/src/main/java/com/sarapis/orservice/controller/LocationController.java
@@ -37,7 +37,7 @@ public class LocationController {
 
     @GetMapping("/{locationId}")
     public ResponseEntity<LocationDTO> getLocation(@PathVariable String locationId) {
-        LocationDTO location = this.locationService.getLocation(locationId);
+        LocationDTO location = this.locationService.getLocationById(locationId);
         return ResponseEntity.ok(location);
     }
 

--- a/src/main/java/com/sarapis/orservice/controller/OrganizationController.java
+++ b/src/main/java/com/sarapis/orservice/controller/OrganizationController.java
@@ -8,7 +8,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
-import java.util.UUID;
 
 @RestController
 @RequestMapping("/api/organizations")
@@ -22,8 +21,8 @@ public class OrganizationController {
 
     @GetMapping
     public ResponseEntity<PaginationDTO<OrganizationDTO>> getAllOrganizations() {
-        List<OrganizationDTO> organizations = organizationService.getAllOrganizations();
-        PaginationDTO<OrganizationDTO> paginationDTO = PaginationDTO.of(
+        List<OrganizationDTO> organizations = this.organizationService.getAllOrganizations();
+        PaginationDTO<OrganizationDTO> pagination = PaginationDTO.of(
                 organizations.size(),
                 1,
                 1,
@@ -33,33 +32,32 @@ public class OrganizationController {
                 false,
                 organizations
         );
-        return ResponseEntity.ok(paginationDTO);
+        return ResponseEntity.ok(pagination);
     }
 
-    @GetMapping("/{id}")
-    public ResponseEntity<OrganizationDTO> getOrganizationById(@PathVariable String id) {
-        OrganizationDTO organization = organizationService.getOrganizationById(id);
+    @GetMapping("/{organizationId}")
+    public ResponseEntity<OrganizationDTO> getOrganizationById(@PathVariable String organizationId) {
+        OrganizationDTO organization = this.organizationService.getOrganizationById(organizationId);
         return ResponseEntity.ok(organization);
     }
 
     @PostMapping
     public ResponseEntity<OrganizationDTO> createOrganization(@RequestBody OrganizationDTO organizationDTO) {
-        if (organizationDTO.getId() == null) {
-            organizationDTO.setId(UUID.randomUUID().toString());
-        }
-        OrganizationDTO createdOrganization = organizationService.createOrganization(organizationDTO);
+        OrganizationDTO createdOrganization = this.organizationService.createOrganization(organizationDTO);
         return ResponseEntity.ok(createdOrganization);
     }
 
-    @PutMapping("/{id}")
-    public ResponseEntity<OrganizationDTO> updateOrganization(@PathVariable String id, @RequestBody OrganizationDTO organizationDTO) {
-        OrganizationDTO updatedOrganization = organizationService.updateOrganization(id, organizationDTO);
+    @PutMapping("/{organizationId}")
+    public ResponseEntity<OrganizationDTO> updateOrganization(@PathVariable String organizationId,
+                                                              @RequestBody OrganizationDTO organizationDTO) {
+        OrganizationDTO updatedOrganization = this.organizationService
+                .updateOrganization(organizationId, organizationDTO);
         return ResponseEntity.ok(updatedOrganization);
     }
 
-    @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deleteOrganization(@PathVariable String id) {
-        organizationService.deleteOrganization(id);
+    @DeleteMapping("/{organizationId}")
+    public ResponseEntity<Void> deleteOrganization(@PathVariable String organizationId) {
+        this.organizationService.deleteOrganization(organizationId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/sarapis/orservice/controller/PhoneController.java
+++ b/src/main/java/com/sarapis/orservice/controller/PhoneController.java
@@ -7,7 +7,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
-import java.util.UUID;
 
 @RestController
 @RequestMapping("/api/phones")
@@ -21,34 +20,31 @@ public class PhoneController {
 
     @GetMapping
     public ResponseEntity<List<PhoneDTO>> getAllPhones() {
-        List<PhoneDTO> phoneDTOs = this.phoneService.getAllPhones();
-        return ResponseEntity.ok(phoneDTOs);
+        List<PhoneDTO> phones = this.phoneService.getAllPhones();
+        return ResponseEntity.ok(phones);
     }
 
-    @GetMapping("/{id}")
-    public ResponseEntity<PhoneDTO> getPhoneById(@PathVariable String id) {
-        PhoneDTO phoneDTO = this.phoneService.getPhoneById(id);
-        return ResponseEntity.ok(phoneDTO);
+    @GetMapping("/{phoneId}")
+    public ResponseEntity<PhoneDTO> getPhoneById(@PathVariable String phoneId) {
+        PhoneDTO phone = this.phoneService.getPhoneById(phoneId);
+        return ResponseEntity.ok(phone);
     }
 
     @PostMapping
     public ResponseEntity<PhoneDTO> createPhone(@RequestBody PhoneDTO phoneDTO) {
-        if (phoneDTO.getId() == null) {
-            phoneDTO.setId(UUID.randomUUID().toString());
-        }
         PhoneDTO createdPhone = this.phoneService.createPhone(phoneDTO);
         return ResponseEntity.ok(createdPhone);
     }
 
-    @PutMapping("/{id}")
-    public ResponseEntity<PhoneDTO> updatePhone(@PathVariable String id, @RequestBody PhoneDTO phoneDTO) {
-        PhoneDTO updatedAccessibility = this.phoneService.updatePhone(id, phoneDTO);
-        return ResponseEntity.ok(updatedAccessibility);
+    @PutMapping("/{phoneId}")
+    public ResponseEntity<PhoneDTO> updatePhone(@PathVariable String phoneId, @RequestBody PhoneDTO phoneDTO) {
+        PhoneDTO updatedPhone = this.phoneService.updatePhone(phoneId, phoneDTO);
+        return ResponseEntity.ok(updatedPhone);
     }
 
-    @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deletePhone(@PathVariable String id) {
-        this.phoneService.deletePhone(id);
+    @DeleteMapping("/{phoneId}")
+    public ResponseEntity<Void> deletePhone(@PathVariable String phoneId) {
+        this.phoneService.deletePhone(phoneId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/sarapis/orservice/controller/ProgramController.java
+++ b/src/main/java/com/sarapis/orservice/controller/ProgramController.java
@@ -2,55 +2,50 @@ package com.sarapis.orservice.controller;
 
 import com.sarapis.orservice.dto.ProgramDTO;
 import com.sarapis.orservice.service.ProgramService;
-import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/programs")
 public class ProgramController {
-  public final ProgramService programService;
+    public final ProgramService programService;
 
-  @Autowired
-  public ProgramController(ProgramService programService) {
-    this.programService = programService;
-  }
+    @Autowired
+    public ProgramController(ProgramService programService) {
+        this.programService = programService;
+    }
 
-  @GetMapping
-  public ResponseEntity<List<ProgramDTO>> getAllPrograms() {
-    List<ProgramDTO> programDTOs = this.programService.getAllPrograms();
-    return ResponseEntity.ok(programDTOs);
-  }
+    @GetMapping
+    public ResponseEntity<List<ProgramDTO>> getAllPrograms() {
+        List<ProgramDTO> programs = this.programService.getAllPrograms();
+        return ResponseEntity.ok(programs);
+    }
 
-  @GetMapping("/{id}")
-  public ResponseEntity<ProgramDTO> getProgramById(@PathVariable String id) {
-    ProgramDTO programDTO = this.programService.getProgramDTOById(id);
-    return ResponseEntity.ok(programDTO);
-  }
+    @GetMapping("/{programId}")
+    public ResponseEntity<ProgramDTO> getProgramById(@PathVariable String programId) {
+        ProgramDTO program = this.programService.getProgramDTOById(programId);
+        return ResponseEntity.ok(program);
+    }
 
-  @PostMapping
-  public ResponseEntity<ProgramDTO> createProgram(@RequestBody ProgramDTO programDTO) {
-    ProgramDTO createdProgramDTO = this.programService.createProgram(programDTO);
-    return ResponseEntity.ok(createdProgramDTO);
-  }
+    @PostMapping
+    public ResponseEntity<ProgramDTO> createProgram(@RequestBody ProgramDTO programDTO) {
+        ProgramDTO createdProgram = this.programService.createProgram(programDTO);
+        return ResponseEntity.ok(createdProgram);
+    }
 
-  @PutMapping("/{id}")
-  public ResponseEntity<ProgramDTO> updateProgram(@PathVariable String id, @RequestBody ProgramDTO programDTO) {
-    ProgramDTO updatedProgramDTO = this.programService.updateProgram(id, programDTO);
-    return ResponseEntity.ok(updatedProgramDTO);
-  }
+    @PutMapping("/{programId}")
+    public ResponseEntity<ProgramDTO> updateProgram(@PathVariable String programId,
+                                                    @RequestBody ProgramDTO programDTO) {
+        ProgramDTO updatedProgram = this.programService.updateProgram(programId, programDTO);
+        return ResponseEntity.ok(updatedProgram);
+    }
 
-  @DeleteMapping("/{id}")
-  public ResponseEntity<Void> deleteProgram(@PathVariable String id) {
-    this.programService.deleteProgram(id);
-    return ResponseEntity.noContent().build();
-  }
+    @DeleteMapping("/{programId}")
+    public ResponseEntity<Void> deleteProgram(@PathVariable String programId) {
+        this.programService.deleteProgram(programId);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/sarapis/orservice/controller/ScheduleController.java
+++ b/src/main/java/com/sarapis/orservice/controller/ScheduleController.java
@@ -7,7 +7,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
-import java.util.UUID;
 
 @RestController
 @RequestMapping("/api/schedule")
@@ -21,34 +20,32 @@ public class ScheduleController {
 
     @GetMapping
     public ResponseEntity<List<ScheduleDTO>> getSchedules() {
-        List<ScheduleDTO> scheduleDTOs = this.scheduleService.getAllSchedules();
-        return ResponseEntity.ok(scheduleDTOs);
+        List<ScheduleDTO> schedules = this.scheduleService.getAllSchedules();
+        return ResponseEntity.ok(schedules);
     }
 
-    @GetMapping("/{id}")
-    public ResponseEntity<ScheduleDTO> getScheduleById(@PathVariable String id) {
-        ScheduleDTO scheduleDTO = this.scheduleService.getScheduleById(id);
-        return ResponseEntity.ok(scheduleDTO);
+    @GetMapping("/{scheduleId}")
+    public ResponseEntity<ScheduleDTO> getScheduleById(@PathVariable String scheduleId) {
+        ScheduleDTO schedule = this.scheduleService.getScheduleById(scheduleId);
+        return ResponseEntity.ok(schedule);
     }
 
     @PostMapping
     public ResponseEntity<ScheduleDTO> createSchedule(@RequestBody ScheduleDTO scheduleDTO) {
-        if(scheduleDTO.getId() == null) {
-            scheduleDTO.setId(UUID.randomUUID().toString());
-        }
-        ScheduleDTO createdScheduleDTO = this.scheduleService.createSchedule(scheduleDTO);
-        return ResponseEntity.ok(createdScheduleDTO);
+        ScheduleDTO createdSchedule = this.scheduleService.createSchedule(scheduleDTO);
+        return ResponseEntity.ok(createdSchedule);
     }
 
-    @PutMapping("/{id}")
-    public ResponseEntity<ScheduleDTO> updateSchedule(@PathVariable String id, @RequestBody ScheduleDTO scheduleDTO) {
-        ScheduleDTO updatedScheduleDTO = this.scheduleService.updateSchedule(id, scheduleDTO);
-        return ResponseEntity.ok(updatedScheduleDTO);
+    @PutMapping("/{scheduleId}")
+    public ResponseEntity<ScheduleDTO> updateSchedule(@PathVariable String scheduleId,
+                                                      @RequestBody ScheduleDTO scheduleDTO) {
+        ScheduleDTO updatedSchedule = this.scheduleService.updateSchedule(scheduleId, scheduleDTO);
+        return ResponseEntity.ok(updatedSchedule);
     }
 
-    @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deleteSchedule(@PathVariable String id) {
-        this.scheduleService.deleteSchedule(id);
+    @DeleteMapping("/{scheduleId}")
+    public ResponseEntity<Void> deleteSchedule(@PathVariable String scheduleId) {
+        this.scheduleService.deleteSchedule(scheduleId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/sarapis/orservice/controller/ServiceAreaController.java
+++ b/src/main/java/com/sarapis/orservice/controller/ServiceAreaController.java
@@ -7,7 +7,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
-import java.util.UUID;
 
 @RestController
 @RequestMapping("/api/service_areas")
@@ -22,34 +21,32 @@ public class ServiceAreaController {
 
     @GetMapping
     public ResponseEntity<List<ServiceAreaDTO>> getAllServiceAreas() {
-        List<ServiceAreaDTO> serviceAreaDTOs = serviceAreaService.getAllServiceAreas();
-        return ResponseEntity.ok(serviceAreaDTOs);
+        List<ServiceAreaDTO> serviceAreas = this.serviceAreaService.getAllServiceAreas();
+        return ResponseEntity.ok(serviceAreas);
     }
 
-    @GetMapping("/{id}")
-    public ResponseEntity<ServiceAreaDTO> getServiceAreaById(@PathVariable String id) {
-        ServiceAreaDTO serviceArea = serviceAreaService.getServiceAreaById(id);
+    @GetMapping("/{serviceAreaId}")
+    public ResponseEntity<ServiceAreaDTO> getServiceAreaById(@PathVariable String serviceAreaId) {
+        ServiceAreaDTO serviceArea = this.serviceAreaService.getServiceAreaById(serviceAreaId);
         return ResponseEntity.ok(serviceArea);
     }
 
     @PostMapping
     public ResponseEntity<ServiceAreaDTO> createServiceArea(@RequestBody ServiceAreaDTO serviceAreaDTO) {
-        if (serviceAreaDTO.getId() == null) {
-            serviceAreaDTO.setId(UUID.randomUUID().toString());
-        }
-        ServiceAreaDTO createdServiceArea = serviceAreaService.createServiceArea(serviceAreaDTO);
+        ServiceAreaDTO createdServiceArea = this.serviceAreaService.createServiceArea(serviceAreaDTO);
         return ResponseEntity.ok(createdServiceArea);
     }
 
-    @PutMapping("/{id}")
-    public ResponseEntity<ServiceAreaDTO> updateServiceArea(@PathVariable String id, @RequestBody ServiceAreaDTO serviceAreaDTO) {
-        ServiceAreaDTO updatedAccessibility = serviceAreaService.updateServiceArea(id, serviceAreaDTO);
-        return ResponseEntity.ok(updatedAccessibility);
+    @PutMapping("/{serviceAreaId}")
+    public ResponseEntity<ServiceAreaDTO> updateServiceArea(@PathVariable String serviceAreaId,
+                                                            @RequestBody ServiceAreaDTO serviceAreaDTO) {
+        ServiceAreaDTO updatedServiceArea = this.serviceAreaService.updateServiceArea(serviceAreaId, serviceAreaDTO);
+        return ResponseEntity.ok(updatedServiceArea);
     }
 
-    @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deleteServiceArea(@PathVariable String id) {
-        serviceAreaService.deleteServiceArea(id);
+    @DeleteMapping("/{serviceAreaId}")
+    public ResponseEntity<Void> deleteServiceArea(@PathVariable String serviceAreaId) {
+        this.serviceAreaService.deleteServiceArea(serviceAreaId);
         return ResponseEntity.noContent().build();
     }
 

--- a/src/main/java/com/sarapis/orservice/controller/ServiceAtLocationController.java
+++ b/src/main/java/com/sarapis/orservice/controller/ServiceAtLocationController.java
@@ -5,66 +5,63 @@ import com.sarapis.orservice.dto.ServiceAtLocationDTO;
 import com.sarapis.orservice.service.ServiceAtLocationService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
 @RestController
 @RequestMapping("/api/service_at_locations")
 public class ServiceAtLocationController {
-  private final ServiceAtLocationService serviceAtLocationService;
+    private final ServiceAtLocationService serviceAtLocationService;
 
-  @Autowired
-  public ServiceAtLocationController(ServiceAtLocationService serviceAtLocationService) {
-    this.serviceAtLocationService = serviceAtLocationService;
-  }
+    @Autowired
+    public ServiceAtLocationController(ServiceAtLocationService serviceAtLocationService) {
+        this.serviceAtLocationService = serviceAtLocationService;
+    }
 
-  @GetMapping
-  public ResponseEntity<PaginationDTO<ServiceAtLocationDTO>> getAllServiceAtLocations() {
-    List<ServiceAtLocationDTO> servLocDTOs = this.serviceAtLocationService.getAllServicesAtLocation();
-    PaginationDTO<ServiceAtLocationDTO> paginationDTO = PaginationDTO.of(
-            servLocDTOs.size(),
-            1,
-            1,
-            servLocDTOs.size(),
-            true,
-            false,
-            false,
-            servLocDTOs
-    );
+    @GetMapping
+    public ResponseEntity<PaginationDTO<ServiceAtLocationDTO>> getAllServiceAtLocations() {
+        List<ServiceAtLocationDTO> servicesAtLocations = this.serviceAtLocationService.getAllServicesAtLocation();
+        PaginationDTO<ServiceAtLocationDTO> pagination = PaginationDTO.of(
+                servicesAtLocations.size(),
+                1,
+                1,
+                servicesAtLocations.size(),
+                true,
+                false,
+                false,
+                servicesAtLocations
+        );
+        return ResponseEntity.ok(pagination);
+    }
 
-    return ResponseEntity.ok(paginationDTO);
-  }
+    @GetMapping("/{serviceAtLocationId}")
+    public ResponseEntity<ServiceAtLocationDTO> getServiceAtLocationById(@PathVariable String serviceAtLocationId) {
+        ServiceAtLocationDTO serviceAtLocation = this.serviceAtLocationService
+                .getServiceAtLocationById(serviceAtLocationId);
+        return ResponseEntity.ok(serviceAtLocation);
+    }
 
-  @GetMapping("/{id}")
-  public ResponseEntity<ServiceAtLocationDTO> getServiceAtLocationById(@PathVariable String id) {
-    ServiceAtLocationDTO servLocDTO = this.serviceAtLocationService.getServiceAtLocationById(id);
-    return ResponseEntity.ok(servLocDTO);
-  }
+    @PostMapping
+    public ResponseEntity<ServiceAtLocationDTO> createServiceAtLocation(
+            @RequestBody ServiceAtLocationDTO serviceAtLocationDTO) {
+        ServiceAtLocationDTO createdServiceAtLocation = this.serviceAtLocationService
+                .createServiceAtLocation(serviceAtLocationDTO);
+        return ResponseEntity.ok(createdServiceAtLocation);
+    }
 
-  @PostMapping
-  public ResponseEntity<ServiceAtLocationDTO> createServiceAtLocation(@RequestBody ServiceAtLocationDTO serviceAtLocationDTO) {
-    ServiceAtLocationDTO createdServLocDTO = this.serviceAtLocationService.createServiceAtLocation(serviceAtLocationDTO);
-    return ResponseEntity.ok(createdServLocDTO);
-  }
+    @PutMapping("/{serviceAtLocationId}")
+    public ResponseEntity<ServiceAtLocationDTO> updateServiceAtLocation(@PathVariable String serviceAtLocationId,
+                                                                        @RequestBody ServiceAtLocationDTO serviceAtLocationDTO) {
+        ServiceAtLocationDTO updatedServiceAtLocation = this.serviceAtLocationService
+                .updateServiceAtLocation(serviceAtLocationId, serviceAtLocationDTO);
+        return ResponseEntity.ok(updatedServiceAtLocation);
+    }
 
-  @PutMapping("/{id}")
-  public ResponseEntity<ServiceAtLocationDTO> updateServiceAtLocation(@PathVariable String id, @RequestBody ServiceAtLocationDTO serviceAtLocationDTO) {
-    ServiceAtLocationDTO updatedServLocDTO = this.serviceAtLocationService.updateServiceAtLocation(id, serviceAtLocationDTO);
-    return ResponseEntity.ok(updatedServLocDTO);
-  }
-
-  @DeleteMapping("/{id}")
-  public ResponseEntity<Void> deleteServiceAtLocation(@PathVariable String id) {
-    serviceAtLocationService.deleteServiceAtLocation(id);
-    return ResponseEntity.noContent().build();
-  }
+    @DeleteMapping("/{serviceAtLocationId}")
+    public ResponseEntity<Void> deleteServiceAtLocation(@PathVariable String serviceAtLocationId) {
+        this.serviceAtLocationService.deleteServiceAtLocation(serviceAtLocationId);
+        return ResponseEntity.noContent().build();
+    }
 
 }

--- a/src/main/java/com/sarapis/orservice/controller/ServiceController.java
+++ b/src/main/java/com/sarapis/orservice/controller/ServiceController.java
@@ -3,62 +3,60 @@ package com.sarapis.orservice.controller;
 import com.sarapis.orservice.dto.PaginationDTO;
 import com.sarapis.orservice.dto.ServiceDTO;
 import com.sarapis.orservice.service.ServiceService;
-import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/services")
 public class ServiceController {
-  private final ServiceService serviceService;
+    private final ServiceService serviceService;
 
-  @Autowired
-  public ServiceController(ServiceService service) {
-    this.serviceService = service;
-  }
+    @Autowired
+    public ServiceController(ServiceService service) {
+        this.serviceService = service;
+    }
 
-  @GetMapping
-  public ResponseEntity<PaginationDTO<ServiceDTO>> getAllServices() {
-    List<ServiceDTO> services = serviceService.getAllServices();
-    PaginationDTO<ServiceDTO> paginationDTO = PaginationDTO.of(
-        services.size(),
-        1,
-        1,
-        services.size(),
-        true,
-        false,
-        false,
-        services
-    );
-    return ResponseEntity.ok(paginationDTO);
-  }
+    @GetMapping
+    public ResponseEntity<PaginationDTO<ServiceDTO>> getAllServices() {
+        List<ServiceDTO> services = this.serviceService.getAllServices();
+        PaginationDTO<ServiceDTO> pagination = PaginationDTO.of(
+                services.size(),
+                1,
+                1,
+                services.size(),
+                true,
+                false,
+                false,
+                services
+        );
+        return ResponseEntity.ok(pagination);
+    }
 
-  @GetMapping("/{id}")
-  public ResponseEntity<ServiceDTO> getServiceById(@PathVariable String id) {
-    return null;
-  }
+    @GetMapping("/{serviceId}")
+    public ResponseEntity<ServiceDTO> getServiceById(@PathVariable String serviceId) {
+        ServiceDTO service = this.serviceService.getServiceById(serviceId);
+        return ResponseEntity.ok(service);
+    }
 
-  @PostMapping
-  public ResponseEntity<ServiceDTO> createService(@RequestBody ServiceDTO serviceDTO) {
-    return null;
-  }
+    @PostMapping
+    public ResponseEntity<ServiceDTO> createService(@RequestBody ServiceDTO serviceDTO) {
+        ServiceDTO createdService = this.serviceService.createService(serviceDTO);
+        return ResponseEntity.ok(createdService);
+    }
 
-  @PutMapping("/{id}")
-  public ResponseEntity<ServiceDTO> updateService(@PathVariable String id, @RequestBody ServiceDTO serviceDTO) {
-    return null;
-  }
+    @PutMapping("/{serviceId}")
+    public ResponseEntity<ServiceDTO> updateService(@PathVariable String serviceId,
+                                                    @RequestBody ServiceDTO serviceDTO) {
+        ServiceDTO updatedService = this.serviceService.updateService(serviceId, serviceDTO);
+        return ResponseEntity.ok(updatedService);
+    }
 
-  @DeleteMapping("/{id}")
-  public ResponseEntity<Void> deleteService(@PathVariable String id) {
-    serviceService.deleteService(id);
-    return ResponseEntity.noContent().build();
-  }
+    @DeleteMapping("/{serviceId}")
+    public ResponseEntity<Void> deleteService(@PathVariable String serviceId) {
+        this.serviceService.deleteService(serviceId);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/sarapis/orservice/controller/TaxonomyController.java
+++ b/src/main/java/com/sarapis/orservice/controller/TaxonomyController.java
@@ -1,52 +1,51 @@
 package com.sarapis.orservice.controller;
 
-import com.sarapis.orservice.dto.PaginationDTO;
 import com.sarapis.orservice.dto.TaxonomyDTO;
 import com.sarapis.orservice.service.TaxonomyService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/taxonomies")
 public class TaxonomyController {
-  private final TaxonomyService taxonomyService;
+    private final TaxonomyService taxonomyService;
 
-  @Autowired
-  public TaxonomyController(TaxonomyService taxonomyService) {
-    this.taxonomyService = taxonomyService;
-  }
+    @Autowired
+    public TaxonomyController(TaxonomyService taxonomyService) {
+        this.taxonomyService = taxonomyService;
+    }
 
-  @GetMapping
-  public ResponseEntity<PaginationDTO<TaxonomyDTO>> getAllTaxonomies() {
-    return null;
-  }
+    @GetMapping
+    public ResponseEntity<List<TaxonomyDTO>> getAllTaxonomies() {
+        List<TaxonomyDTO> taxonomies = this.taxonomyService.getAllTaxonomies();
+        return ResponseEntity.ok(taxonomies);
+    }
 
-  @GetMapping("/{id}")
-  public ResponseEntity<TaxonomyDTO> getTaxonomyById(@PathVariable String id) {
-    return null;
-  }
+    @GetMapping("/{taxonomyId}")
+    public ResponseEntity<TaxonomyDTO> getTaxonomyById(@PathVariable String taxonomyId) {
+        TaxonomyDTO taxonomy = this.taxonomyService.getTaxonomyById(taxonomyId);
+        return ResponseEntity.ok(taxonomy);
+    }
 
-  @PostMapping
-  public ResponseEntity<TaxonomyDTO> createTaxonomy(@RequestBody TaxonomyDTO taxonomyDTO) {
-    return null;
-  }
+    @PostMapping
+    public ResponseEntity<TaxonomyDTO> createTaxonomy(@RequestBody TaxonomyDTO taxonomyDTO) {
+        TaxonomyDTO createdTaxonomy = this.taxonomyService.createTaxonomy(taxonomyDTO);
+        return ResponseEntity.ok(createdTaxonomy);
+    }
 
-  @PutMapping("/{id}")
-  public ResponseEntity<TaxonomyDTO> updateTaxonomy(@PathVariable String id, @RequestBody TaxonomyDTO taxonomyDTO) {
-    return null;
-  }
+    @PutMapping("/{taxonomyId}")
+    public ResponseEntity<TaxonomyDTO> updateTaxonomy(@PathVariable String taxonomyId,
+                                                      @RequestBody TaxonomyDTO taxonomyDTO) {
+        TaxonomyDTO updatedTaxonomy = this.taxonomyService.updateTaxonomy(taxonomyId, taxonomyDTO);
+        return ResponseEntity.ok(updatedTaxonomy);
+    }
 
-  @DeleteMapping("/{id}")
-  public ResponseEntity<Void> deleteTaxonomy(@PathVariable String id) {
-    taxonomyService.deleteTaxonomy(id);
-    return ResponseEntity.noContent().build();
-  }
+    @DeleteMapping("/{taxonomyId}")
+    public ResponseEntity<Void> deleteTaxonomy(@PathVariable String taxonomyId) {
+        taxonomyService.deleteTaxonomy(taxonomyId);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/sarapis/orservice/controller/TaxonomyTermController.java
+++ b/src/main/java/com/sarapis/orservice/controller/TaxonomyTermController.java
@@ -1,54 +1,51 @@
 package com.sarapis.orservice.controller;
 
-import com.sarapis.orservice.dto.PaginationDTO;
 import com.sarapis.orservice.dto.TaxonomyTermDTO;
 import com.sarapis.orservice.service.TaxonomyTermService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/taxonomy_terms")
 public class TaxonomyTermController {
-  private final TaxonomyTermService taxonomyTermService;
+    private final TaxonomyTermService taxonomyTermService;
 
-  @Autowired
-  public TaxonomyTermController(TaxonomyTermService taxonomyTermService) {
-    this.taxonomyTermService = taxonomyTermService;
-  }
+    @Autowired
+    public TaxonomyTermController(TaxonomyTermService taxonomyTermService) {
+        this.taxonomyTermService = taxonomyTermService;
+    }
 
-  @GetMapping
-  public ResponseEntity<PaginationDTO<TaxonomyTermDTO>> getAllTaxonomyTerms() {
-    return null;
-  }
+    @GetMapping
+    public ResponseEntity<List<TaxonomyTermDTO>> getAllTaxonomyTerms() {
+        List<TaxonomyTermDTO> taxonomyTerms = this.taxonomyTermService.getAllTaxonomyTerms();
+        return ResponseEntity.ok(taxonomyTerms);
+    }
 
-  @GetMapping("/{id}")
-  public ResponseEntity<TaxonomyTermDTO> getTaxonomyTermById(@PathVariable String id) {
-    return null;
-  }
+    @GetMapping("/{id}")
+    public ResponseEntity<TaxonomyTermDTO> getTaxonomyTermById(@PathVariable String id) {
+        TaxonomyTermDTO taxonomyTerm = this.taxonomyTermService.getTaxonomyTermById(id);
+        return ResponseEntity.ok(taxonomyTerm);
+    }
 
-  @PostMapping
-  public ResponseEntity<TaxonomyTermDTO> createTaxonomyTerm(@RequestBody TaxonomyTermDTO taxonomyTermDTO) {
-    return null;
-  }
+    @PostMapping
+    public ResponseEntity<TaxonomyTermDTO> createTaxonomyTerm(@RequestBody TaxonomyTermDTO taxonomyTermDTO) {
+        TaxonomyTermDTO createdTaxonomyTerm = this.taxonomyTermService.createTaxonomyTerm(taxonomyTermDTO);
+        return ResponseEntity.ok(createdTaxonomyTerm);
+    }
 
-  @PutMapping("/{id}")
-  public ResponseEntity<TaxonomyTermDTO> updateTaxonomyTerm(@PathVariable String id, @RequestBody TaxonomyTermDTO taxonomyTermDTO) {
-    return null;
-  }
+    @PutMapping("/{id}")
+    public ResponseEntity<TaxonomyTermDTO> updateTaxonomyTerm(@PathVariable String id,
+                                                              @RequestBody TaxonomyTermDTO taxonomyTermDTO) {
+        TaxonomyTermDTO updatedTaxonomyTerm = this.taxonomyTermService.updateTaxonomyTerm(id, taxonomyTermDTO);
+        return ResponseEntity.ok(updatedTaxonomyTerm);
+    }
 
-  @DeleteMapping("/{id}")
-  public ResponseEntity<Void> deleteTaxonomyTerm(@PathVariable String id) {
-    taxonomyTermService.deleteTaxonomyTerm(id);
-    return ResponseEntity.noContent().build();
-  }
-
-
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteTaxonomyTerm(@PathVariable String id) {
+        this.taxonomyTermService.deleteTaxonomyTerm(id);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/sarapis/orservice/dto/AccessibilityDTO.java
+++ b/src/main/java/com/sarapis/orservice/dto/AccessibilityDTO.java
@@ -1,10 +1,12 @@
 package com.sarapis.orservice.dto;
 
 import com.sarapis.orservice.entity.Accessibility;
+import com.sarapis.orservice.entity.core.Location;
 import lombok.*;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 @Getter
 @Setter
@@ -13,17 +15,21 @@ import java.util.List;
 @Builder
 public class AccessibilityDTO {
     private String id;
+
+    private String locationId;
+
     private String description;
     private String details;
     private String url;
+
     private List<AttributeDTO> attributes = new ArrayList<>();
     private List<MetadataDTO> metadata = new ArrayList<>();
 
-    public Accessibility toEntity() {
+    public Accessibility toEntity(Location location) {
         return Accessibility.builder()
-                .id(this.id)
-                .description(this.description)
-                .details(this.details)
+                .id(this.id == null ? UUID.randomUUID().toString() : this.id)
+                .location(location)
+                .description(this.description).details(this.details)
                 .url(this.url)
                 .build();
     }

--- a/src/main/java/com/sarapis/orservice/dto/AddressDTO.java
+++ b/src/main/java/com/sarapis/orservice/dto/AddressDTO.java
@@ -2,10 +2,12 @@ package com.sarapis.orservice.dto;
 
 import com.sarapis.orservice.entity.Address;
 import com.sarapis.orservice.entity.AddressType;
+import com.sarapis.orservice.entity.core.Location;
 import lombok.*;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 @Getter
 @Setter
@@ -14,6 +16,9 @@ import java.util.List;
 @Builder
 public class AddressDTO {
     private String id;
+
+    private String locationId;
+
     private String attention;
     private String address_1;
     private String address_2;
@@ -23,12 +28,14 @@ public class AddressDTO {
     private String postalCode;
     private String country;
     private AddressType addressType;
+
     private List<AttributeDTO> attributes = new ArrayList<>();
     private List<MetadataDTO> metadata = new ArrayList<>();
 
-    public Address toEntity() {
+    public Address toEntity(Location location) {
         return Address.builder()
-                .id(this.id)
+                .id(this.id == null ? UUID.randomUUID().toString() : this.id)
+                .location(location)
                 .attention(this.attention)
                 .address_1(this.address_1)
                 .address_2(this.address_2)

--- a/src/main/java/com/sarapis/orservice/dto/AttributeDTO.java
+++ b/src/main/java/com/sarapis/orservice/dto/AttributeDTO.java
@@ -6,6 +6,7 @@ import lombok.*;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 @Getter
 @Setter
@@ -14,23 +15,27 @@ import java.util.List;
 @Builder
 public class AttributeDTO {
     private String id;
+
     private String linkId;
+
     private String linkType;
     private LinkEntity linkEntity;
     private String value;
-    private TaxonomyTermDTO taxonomyTerm;
     private String label;
+
+    private TaxonomyTermDTO taxonomyTerm;
     private List<MetadataDTO> metadata = new ArrayList<>();
 
     public Attribute toEntity(String linkId) {
-        return Attribute.builder()
-                .id(this.id)
+        Attribute attribute = Attribute.builder()
+                .id(this.id == null ? UUID.randomUUID().toString() : this.id)
                 .linkId(linkId)
                 .linkType(this.linkType)
                 .linkEntity(this.linkEntity)
                 .value(this.value)
-                .taxonomyTerm(this.taxonomyTerm.toEntity())
                 .label(this.label)
                 .build();
+        attribute.setTaxonomyTerm(this.taxonomyTerm.toEntity(null));
+        return attribute;
     }
 }

--- a/src/main/java/com/sarapis/orservice/dto/ContactDTO.java
+++ b/src/main/java/com/sarapis/orservice/dto/ContactDTO.java
@@ -1,10 +1,15 @@
 package com.sarapis.orservice.dto;
 
 import com.sarapis.orservice.entity.Contact;
+import com.sarapis.orservice.entity.core.Location;
+import com.sarapis.orservice.entity.core.Organization;
+import com.sarapis.orservice.entity.core.Service;
+import com.sarapis.orservice.entity.core.ServiceAtLocation;
 import lombok.*;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 @Getter
 @Setter
@@ -13,22 +18,37 @@ import java.util.List;
 @Builder
 public class ContactDTO {
     private String id;
+
+    private String organizationId;
+    private String serviceId;
+    private String serviceAtLocationId;
+    private String locationId;
+
     private String name;
     private String title;
     private String department;
     private String email;
+
     private List<PhoneDTO> phones = new ArrayList<>();
     private List<AttributeDTO> attributes = new ArrayList<>();
     private List<MetadataDTO> metadata = new ArrayList<>();
 
-    public Contact toEntity() {
-        return Contact.builder()
-                .id(this.id)
+    public Contact toEntity(Organization organization,
+                            Service service,
+                            ServiceAtLocation serviceAtLocation,
+                            Location location) {
+        Contact contact = Contact.builder()
+                .id(this.id == null ? UUID.randomUUID().toString() : this.id)
+                .organization(organization)
+                .service(service)
+                .serviceAtLocation(serviceAtLocation)
+                .location(location)
                 .name(this.name)
                 .title(this.title)
                 .department(this.department)
                 .email(this.email)
-                .phones(this.phones.stream().map(PhoneDTO::toEntity).toList())
                 .build();
+        contact.setPhones(this.phones.stream().map(e -> e.toEntity(null, null, null, contact, null)).toList());
+        return contact;
     }
 }

--- a/src/main/java/com/sarapis/orservice/dto/CostOptionDTO.java
+++ b/src/main/java/com/sarapis/orservice/dto/CostOptionDTO.java
@@ -1,11 +1,13 @@
 package com.sarapis.orservice.dto;
 
 import com.sarapis.orservice.entity.CostOption;
+import com.sarapis.orservice.entity.core.Service;
 import lombok.*;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 @Getter
 @Setter
@@ -14,18 +16,23 @@ import java.util.List;
 @Builder
 public class CostOptionDTO {
     private String id;
+
+    private String serviceId;
+
     private LocalDate validFrom;
     private LocalDate validTo;
     private String option;
     private String currency;
     private int amount;
     private String amountDescription;
+
     private List<AttributeDTO> attributes = new ArrayList<>();
     private List<MetadataDTO> metadata = new ArrayList<>();
 
-    public CostOption toEntity() {
+    public CostOption toEntity(Service service) {
         return CostOption.builder()
-                .id(this.id)
+                .id(this.id == null ? UUID.randomUUID().toString() : this.id)
+                .service(service)
                 .validFrom(this.validFrom)
                 .validTo(this.validTo)
                 .option(this.option)

--- a/src/main/java/com/sarapis/orservice/dto/FundingDTO.java
+++ b/src/main/java/com/sarapis/orservice/dto/FundingDTO.java
@@ -1,10 +1,13 @@
 package com.sarapis.orservice.dto;
 
 import com.sarapis.orservice.entity.Funding;
+import com.sarapis.orservice.entity.core.Organization;
+import com.sarapis.orservice.entity.core.Service;
 import lombok.*;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 @Getter
 @Setter
@@ -13,13 +16,20 @@ import java.util.List;
 @Builder
 public class FundingDTO {
     private String id;
+
+    private String organizationId;
+    private String serviceId;
+
     private String source;
+
     private List<AttributeDTO> attributes = new ArrayList<>();
     private List<MetadataDTO> metadata = new ArrayList<>();
 
-    public Funding toEntity() {
+    public Funding toEntity(Organization organization, Service service) {
         return Funding.builder()
-                .id(this.id)
+                .id(this.id == null ? UUID.randomUUID().toString() : this.id)
+                .organization(organization)
+                .service(service)
                 .source(this.source)
                 .build();
     }

--- a/src/main/java/com/sarapis/orservice/dto/LanguageDTO.java
+++ b/src/main/java/com/sarapis/orservice/dto/LanguageDTO.java
@@ -1,10 +1,14 @@
 package com.sarapis.orservice.dto;
 
 import com.sarapis.orservice.entity.Language;
+import com.sarapis.orservice.entity.Phone;
+import com.sarapis.orservice.entity.core.Location;
+import com.sarapis.orservice.entity.core.Service;
 import lombok.*;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 @Getter
 @Setter
@@ -13,15 +17,24 @@ import java.util.List;
 @Builder
 public class LanguageDTO {
     private String id;
+
+    private String serviceId;
+    private String locationId;
+    private String phoneId;
+
     private String name;
     private String code;
     private String note;
+
     private List<AttributeDTO> attributes = new ArrayList<>();
     private List<MetadataDTO> metadata = new ArrayList<>();
 
-    public Language toEntity() {
+    public Language toEntity(Service service, Location location, Phone phone) {
         return Language.builder()
-                .id(this.id)
+                .id(this.id == null ? UUID.randomUUID().toString() : this.id)
+                .service(service)
+                .location(location)
+                .phone(phone)
                 .name(this.name)
                 .code(this.code)
                 .note(this.note)

--- a/src/main/java/com/sarapis/orservice/dto/LocationDTO.java
+++ b/src/main/java/com/sarapis/orservice/dto/LocationDTO.java
@@ -2,10 +2,12 @@ package com.sarapis.orservice.dto;
 
 import com.sarapis.orservice.entity.core.Location;
 import com.sarapis.orservice.entity.core.LocationType;
+import com.sarapis.orservice.entity.core.Organization;
 import lombok.*;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 @Getter
 @Setter
@@ -14,6 +16,9 @@ import java.util.List;
 @Builder
 public class LocationDTO {
     private String id;
+
+    private String organizationId;
+
     private LocationType locationType;
     private String url;
     private String name;
@@ -24,6 +29,7 @@ public class LocationDTO {
     private int longitude;
     private String externalIdentifier;
     private String externalIdentifierType;
+
     private List<LanguageDTO> languages = new ArrayList<>();
     private List<AddressDTO> addresses = new ArrayList<>();
     private List<ContactDTO> contacts = new ArrayList<>();
@@ -33,12 +39,12 @@ public class LocationDTO {
     private List<AttributeDTO> attributes = new ArrayList<>();
     private List<MetadataDTO> metadata = new ArrayList<>();
 
-    public Location toEntity() {
-        return Location.builder()
-                .id(this.id)
+    public Location toEntity(Organization organization) {
+        Location location = Location.builder()
+                .id(this.id == null ? UUID.randomUUID().toString() : this.id)
+                .organization(organization)
                 .locationType(this.locationType)
-                .url(this.url)
-                .name(this.name)
+                .url(this.url).name(this.name)
                 .alternateName(this.alternateName)
                 .description(this.description)
                 .transportation(this.transportation)
@@ -46,12 +52,13 @@ public class LocationDTO {
                 .longitude(this.longitude)
                 .externalIdentifier(this.externalIdentifier)
                 .externalIdentifierType(this.externalIdentifierType)
-                .languages(this.languages.stream().map(LanguageDTO::toEntity).toList())
-                .addresses(this.addresses.stream().map(AddressDTO::toEntity).toList())
-                .contacts(this.contacts.stream().map(ContactDTO::toEntity).toList())
-                .accessibility(this.accessibility.stream().map(AccessibilityDTO::toEntity).toList())
-                .phones(this.phones.stream().map(PhoneDTO::toEntity).toList())
-                .schedules(this.schedules.stream().map(ScheduleDTO::toEntity).toList())
                 .build();
+        location.setLanguages(this.languages.stream().map(e -> e.toEntity(null, location, null)).toList());
+        location.setAddresses(this.addresses.stream().map(e -> e.toEntity(location)).toList());
+        location.setContacts(this.contacts.stream().map(e -> e.toEntity(null, null, null, location)).toList());
+        location.setAccessibility(this.accessibility.stream().map(e -> e.toEntity(location)).toList());
+        location.setPhones(this.phones.stream().map(e -> e.toEntity(location, null, null, null, null)).toList());
+        location.setSchedules(this.schedules.stream().map(e -> e.toEntity(null, location, null)).toList());
+        return location;
     }
 }

--- a/src/main/java/com/sarapis/orservice/dto/MetaTableDescriptionDTO.java
+++ b/src/main/java/com/sarapis/orservice/dto/MetaTableDescriptionDTO.java
@@ -5,6 +5,7 @@ import lombok.*;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 @Setter
 @Getter
@@ -13,15 +14,17 @@ import java.util.List;
 @Builder
 public class MetaTableDescriptionDTO {
     private String id;
+
     private String name;
     private String language;
     private String characterSet;
+
     private List<AttributeDTO> attributes = new ArrayList<>();
     private List<MetadataDTO> metadata = new ArrayList<>();
 
     public MetaTableDescription toEntity() {
         return MetaTableDescription.builder()
-                .id(this.id)
+                .id(this.id == null ? UUID.randomUUID().toString() : this.id)
                 .name(this.name)
                 .language(this.language)
                 .characterSet(this.characterSet)

--- a/src/main/java/com/sarapis/orservice/dto/MetadataDTO.java
+++ b/src/main/java/com/sarapis/orservice/dto/MetadataDTO.java
@@ -5,6 +5,7 @@ import com.sarapis.orservice.entity.ResourceType;
 import lombok.*;
 
 import java.time.LocalDate;
+import java.util.UUID;
 
 @Getter
 @Setter
@@ -13,7 +14,9 @@ import java.time.LocalDate;
 @Builder
 public class MetadataDTO {
     private String id;
+
     private String resourceId;
+
     private ResourceType resourceType;
     private LocalDate lastActionDate;
     private String lastActionType;
@@ -24,7 +27,7 @@ public class MetadataDTO {
 
     public Metadata toEntity(String resourceId) {
         return Metadata.builder()
-                .id(this.id)
+                .id(this.id == null ? UUID.randomUUID().toString() : this.id)
                 .resourceId(resourceId)
                 .resourceType(this.resourceType)
                 .lastActionDate(this.lastActionDate)

--- a/src/main/java/com/sarapis/orservice/dto/OrganizationIdentifierDTO.java
+++ b/src/main/java/com/sarapis/orservice/dto/OrganizationIdentifierDTO.java
@@ -1,10 +1,12 @@
 package com.sarapis.orservice.dto;
 
 import com.sarapis.orservice.entity.OrganizationIdentifier;
+import com.sarapis.orservice.entity.core.Organization;
 import lombok.*;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 @Getter
 @Setter
@@ -13,15 +15,19 @@ import java.util.List;
 @Builder
 public class OrganizationIdentifierDTO {
     private String id;
+
+    private String organizationId;
+
     private String identifierScheme;
     private String identifierType;
     private String identifier;
     private List<AttributeDTO> attributes = new ArrayList<>();
     private List<MetadataDTO> metadata = new ArrayList<>();
 
-    public OrganizationIdentifier toEntity() {
+    public OrganizationIdentifier toEntity(Organization organization) {
         return OrganizationIdentifier.builder()
-                .id(this.id)
+                .id(this.id == null ? UUID.randomUUID().toString() : this.id)
+                .organization(organization)
                 .identifierScheme(this.identifierScheme)
                 .identifierType(this.identifierType)
                 .identifier(this.identifier)

--- a/src/main/java/com/sarapis/orservice/dto/PaginationDTO.java
+++ b/src/main/java/com/sarapis/orservice/dto/PaginationDTO.java
@@ -18,14 +18,8 @@ public class PaginationDTO<T> {
     private boolean empty;
     private List<T> contents;
 
-    public static <T> PaginationDTO<T> of(int totalItems,
-                                          int totalPages,
-                                          int pageNumber,
-                                          int size,
-                                          boolean firstPage,
-                                          boolean lastPage,
-                                          boolean empty,
-                                          List<T> contents) {
+    public static <T> PaginationDTO<T> of(int totalItems, int totalPages, int pageNumber, int size, boolean firstPage,
+            boolean lastPage, boolean empty, List<T> contents) {
         PaginationDTO<T> paginationDTO = new PaginationDTO<>();
         paginationDTO.setTotalItems(totalItems);
         paginationDTO.setTotalPages(totalPages);

--- a/src/main/java/com/sarapis/orservice/dto/PhoneDTO.java
+++ b/src/main/java/com/sarapis/orservice/dto/PhoneDTO.java
@@ -1,10 +1,16 @@
 package com.sarapis.orservice.dto;
 
+import com.sarapis.orservice.entity.Contact;
 import com.sarapis.orservice.entity.Phone;
+import com.sarapis.orservice.entity.core.Location;
+import com.sarapis.orservice.entity.core.Organization;
+import com.sarapis.orservice.entity.core.Service;
+import com.sarapis.orservice.entity.core.ServiceAtLocation;
 import lombok.*;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 @Getter
 @Setter
@@ -13,22 +19,40 @@ import java.util.List;
 @Builder
 public class PhoneDTO {
     private String id;
+
+    private String locationId;
+    private String serviceId;
+    private String organizationId;
+    private String contactId;
+    private String serviceAtLocationId;
+
     private String number;
     private String extension;
     private String type;
     private String description;
+
     private List<LanguageDTO> languages = new ArrayList<>();
     private List<AttributeDTO> attributes = new ArrayList<>();
     private List<MetadataDTO> metadata = new ArrayList<>();
 
-    public Phone toEntity() {
-        return Phone.builder()
-                .id(this.id)
+    public Phone toEntity(Location location,
+                          Service service,
+                          Organization organization,
+                          Contact contact,
+                          ServiceAtLocation serviceAtLocation) {
+        Phone phone = Phone.builder()
+                .id(this.id == null ? UUID.randomUUID().toString() : this.id)
+                .location(location)
+                .service(service)
+                .organization(organization)
+                .contact(contact)
+                .serviceAtLocation(serviceAtLocation)
                 .number(this.number)
                 .extension(this.extension)
                 .type(this.type)
                 .description(this.description)
-                .languages(this.languages.stream().map(LanguageDTO::toEntity).toList())
                 .build();
+        phone.setLanguages(this.languages.stream().map(e -> e.toEntity(null, null, phone)).toList());
+        return phone;
     }
 }

--- a/src/main/java/com/sarapis/orservice/dto/ProgramDTO.java
+++ b/src/main/java/com/sarapis/orservice/dto/ProgramDTO.java
@@ -1,10 +1,12 @@
 package com.sarapis.orservice.dto;
 
 import com.sarapis.orservice.entity.Program;
+import com.sarapis.orservice.entity.core.Organization;
 import lombok.*;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 @Getter
 @Setter
@@ -13,15 +15,20 @@ import java.util.List;
 @Builder
 public class ProgramDTO {
     private String id;
+
+    private String organizationId;
+
     private String name;
     private String alternateName;
     private String description;
+
     private List<AttributeDTO> attributes = new ArrayList<>();
     private List<MetadataDTO> metadata = new ArrayList<>();
 
-    public Program toEntity() {
+    public Program toEntity(Organization organization) {
         return Program.builder()
-                .id(this.id)
+                .id(this.id == null ? UUID.randomUUID().toString() : this.id)
+                .organization(organization)
                 .name(this.name)
                 .alternateName(this.alternateName)
                 .description(this.description)

--- a/src/main/java/com/sarapis/orservice/dto/RequiredDocumentDTO.java
+++ b/src/main/java/com/sarapis/orservice/dto/RequiredDocumentDTO.java
@@ -1,10 +1,12 @@
 package com.sarapis.orservice.dto;
 
 import com.sarapis.orservice.entity.RequiredDocument;
+import com.sarapis.orservice.entity.core.Service;
 import lombok.*;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 @Getter
 @Setter
@@ -13,14 +15,19 @@ import java.util.List;
 @Builder
 public class RequiredDocumentDTO {
     private String id;
+
+    private String serviceId;
+
     private String document;
     private String uri;
+
     private List<AttributeDTO> attributes = new ArrayList<>();
     private List<MetadataDTO> metadata = new ArrayList<>();
 
-    public RequiredDocument toEntity() {
+    public RequiredDocument toEntity(Service service) {
         return RequiredDocument.builder()
-                .id(this.id)
+                .id(this.id == null ? UUID.randomUUID().toString() : this.id)
+                .service(service)
                 .document(this.document)
                 .uri(this.uri)
                 .build();

--- a/src/main/java/com/sarapis/orservice/dto/RootDTO.java
+++ b/src/main/java/com/sarapis/orservice/dto/RootDTO.java
@@ -8,7 +8,7 @@ import lombok.*;
 @AllArgsConstructor
 @Builder
 public class RootDTO {
-  private String version;
-  private String profile;
-  private String openapiUrl;
+    private String version;
+    private String profile;
+    private String openapiUrl;
 }

--- a/src/main/java/com/sarapis/orservice/dto/ScheduleDTO.java
+++ b/src/main/java/com/sarapis/orservice/dto/ScheduleDTO.java
@@ -3,12 +3,16 @@ package com.sarapis.orservice.dto;
 import com.sarapis.orservice.entity.Freq;
 import com.sarapis.orservice.entity.Schedule;
 import com.sarapis.orservice.entity.WkSt;
+import com.sarapis.orservice.entity.core.Location;
+import com.sarapis.orservice.entity.core.Service;
+import com.sarapis.orservice.entity.core.ServiceAtLocation;
 import lombok.*;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 @Getter
 @Setter
@@ -17,6 +21,11 @@ import java.util.List;
 @Builder
 public class ScheduleDTO {
     private String id;
+
+    private String serviceId;
+    private String locationId;
+    private String serviceAtLocationId;
+
     private LocalDate validFrom;
     private LocalDate validTo;
     private LocalDate dtStart;
@@ -36,17 +45,20 @@ public class ScheduleDTO {
     private String scheduleLink;
     private String attendingType;
     private String notes;
+
     private List<AttributeDTO> attributes = new ArrayList<>();
     private List<MetadataDTO> metadata = new ArrayList<>();
 
-    public Schedule toEntity() {
+    public Schedule toEntity(Service service, Location location, ServiceAtLocation serviceAtLocation) {
         return Schedule.builder()
-                .id(this.id)
+                .id(this.id == null ? UUID.randomUUID().toString() : this.id)
+                .service(service)
+                .location(location)
+                .serviceAtLocation(serviceAtLocation)
                 .validFrom(this.validFrom)
                 .validTo(this.validTo)
                 .dtStart(this.dtStart)
-                .timezone(this.timezone)
-                .until(this.until)
+                .timezone(this.timezone).until(this.until)
                 .count(this.count)
                 .wkst(this.wkst)
                 .freq(this.freq)

--- a/src/main/java/com/sarapis/orservice/dto/ServiceAreaDTO.java
+++ b/src/main/java/com/sarapis/orservice/dto/ServiceAreaDTO.java
@@ -2,10 +2,13 @@ package com.sarapis.orservice.dto;
 
 import com.sarapis.orservice.entity.ExtentType;
 import com.sarapis.orservice.entity.ServiceArea;
+import com.sarapis.orservice.entity.core.Service;
+import com.sarapis.orservice.entity.core.ServiceAtLocation;
 import lombok.*;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 @Getter
 @Setter
@@ -14,17 +17,24 @@ import java.util.List;
 @Builder
 public class ServiceAreaDTO {
     private String id;
+
+    private String serviceId;
+    private String serviceAtLocationId;
+
     private String name;
     private String description;
     private String extent;
     private ExtentType extentType;
     private String uri;
+
     private List<AttributeDTO> attributes = new ArrayList<>();
     private List<MetadataDTO> metadata = new ArrayList<>();
 
-    public ServiceArea toEntity() {
+    public ServiceArea toEntity(Service service, ServiceAtLocation serviceAtLocation) {
         return ServiceArea.builder()
-                .id(this.id)
+                .id(this.id == null ? UUID.randomUUID().toString() : this.id)
+                .service(service)
+                .serviceAtLocation(serviceAtLocation)
                 .name(this.name)
                 .description(this.description)
                 .extent(this.extent)

--- a/src/main/java/com/sarapis/orservice/dto/ServiceAtLocationDTO.java
+++ b/src/main/java/com/sarapis/orservice/dto/ServiceAtLocationDTO.java
@@ -1,10 +1,13 @@
 package com.sarapis.orservice.dto;
 
+import com.sarapis.orservice.entity.core.Location;
+import com.sarapis.orservice.entity.core.Service;
 import com.sarapis.orservice.entity.core.ServiceAtLocation;
 import lombok.*;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 @Getter
 @Setter
@@ -12,25 +15,32 @@ import java.util.List;
 @AllArgsConstructor
 @Builder
 public class ServiceAtLocationDTO {
-  private String id;
-  private String description;
-  private List<ServiceAreaDTO> serviceAreas = new ArrayList<>();
-  private List<ContactDTO> contacts = new ArrayList<>();
-  private List<PhoneDTO> phones = new ArrayList<>();
-  private List<ScheduleDTO> schedules = new ArrayList<>();
-  private LocationDTO location;
-  private List<AttributeDTO> attributes = new ArrayList<>();
-  private List<MetadataDTO> metadata = new ArrayList<>();
+    private String id;
 
-  public ServiceAtLocation toEntity() {
-    return ServiceAtLocation.builder()
-            .id(this.id)
-            .description(this.description)
-            .serviceAreas(this.serviceAreas.stream().map(ServiceAreaDTO::toEntity).toList())
-            .contacts(this.contacts.stream().map(ContactDTO::toEntity).toList())
-            .phones(this.phones.stream().map(PhoneDTO::toEntity).toList())
-            .schedules(this.schedules.stream().map(ScheduleDTO::toEntity).toList())
-            .location(this.location.toEntity())
-            .build();
-  }
+    private String serviceId;
+    private String locationId;
+
+    private String description;
+
+    private List<ServiceAreaDTO> serviceAreas = new ArrayList<>();
+    private List<ContactDTO> contacts = new ArrayList<>();
+    private List<PhoneDTO> phones = new ArrayList<>();
+    private List<ScheduleDTO> schedules = new ArrayList<>();
+    private LocationDTO location;
+    private List<AttributeDTO> attributes = new ArrayList<>();
+    private List<MetadataDTO> metadata = new ArrayList<>();
+
+    public ServiceAtLocation toEntity(Service service, Location location) {
+        ServiceAtLocation serviceAtLocation = ServiceAtLocation.builder()
+                .id(this.id == null ? UUID.randomUUID().toString() : this.id)
+                .service(service)
+                .location(location)
+                .description(this.description)
+                .build();
+        serviceAtLocation.setServiceAreas(this.serviceAreas.stream().map(e -> e.toEntity(null, serviceAtLocation)).toList());
+        serviceAtLocation.setContacts(this.contacts.stream().map(e -> e.toEntity(null, null, serviceAtLocation, null)).toList());
+        serviceAtLocation.setPhones(this.phones.stream().map(e -> e.toEntity(null, null, null, null, serviceAtLocation)).toList());
+        serviceAtLocation.setSchedules(this.schedules.stream().map(e -> e.toEntity(null, null, serviceAtLocation)).toList());
+        return serviceAtLocation;
+    }
 }

--- a/src/main/java/com/sarapis/orservice/dto/ServiceCapacityDTO.java
+++ b/src/main/java/com/sarapis/orservice/dto/ServiceCapacityDTO.java
@@ -1,11 +1,14 @@
 package com.sarapis.orservice.dto;
 
 import com.sarapis.orservice.entity.ServiceCapacity;
+import com.sarapis.orservice.entity.Unit;
+import com.sarapis.orservice.entity.core.Service;
 import lombok.*;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 @Getter
 @Setter
@@ -14,18 +17,23 @@ import java.util.List;
 @Builder
 public class ServiceCapacityDTO {
     private String id;
-    private UnitDTO unit = null;
+
+    private String serviceId;
+    private String unitId;
+
     private int available;
     private int maximum;
     private String description;
     private LocalDate updated;
+
     private List<AttributeDTO> attributes = new ArrayList<>();
     private List<MetadataDTO> metadata = new ArrayList<>();
 
-    public ServiceCapacity toEntity() {
+    public ServiceCapacity toEntity(Service service, Unit unit) {
         return ServiceCapacity.builder()
-                .id(this.id)
-                .unit(this.unit != null ? this.unit.toEntity() : null)
+                .id(this.id == null ? UUID.randomUUID().toString() : this.id)
+                .service(service)
+                .unit(unit)
                 .available(this.available)
                 .maximum(this.maximum)
                 .description(this.description)

--- a/src/main/java/com/sarapis/orservice/dto/ServiceDTO.java
+++ b/src/main/java/com/sarapis/orservice/dto/ServiceDTO.java
@@ -1,7 +1,7 @@
 package com.sarapis.orservice.dto;
 
-import com.sarapis.orservice.entity.Attribute;
-import com.sarapis.orservice.entity.Metadata;
+import com.sarapis.orservice.entity.Program;
+import com.sarapis.orservice.entity.core.Organization;
 import com.sarapis.orservice.entity.core.Service;
 import com.sarapis.orservice.entity.core.Status;
 import lombok.*;
@@ -10,6 +10,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 @Getter
 @Setter
@@ -17,79 +18,83 @@ import java.util.List;
 @AllArgsConstructor
 @Builder
 public class ServiceDTO {
-  private String id;
-  private String name;
-  private String alternateName;
-  private String description;
-  private String url;
-  private List<UrlDTO> additionalUrls = new ArrayList<>();
-  private String email;
-  private Status status;
-  private String interpretationServices;
-  private String applicationProcess;
-  private String feesDescription;
-  private String waitTime;
-  private String fees;
-  private String accreditations;
-  private String eligibilityDescription;
-  private int minimumAge;
-  private int maximumAge;
-  private LocalDate assuredDate;
-  private String assurerEmail;
-  private String licenses;
-  private String alert;
-  private LocalDateTime lastModified;
-  private List<PhoneDTO> phones = new ArrayList<>();
-  private List<ScheduleDTO> schedules = new ArrayList<>();
-  private List<ServiceAreaDTO> serviceAreas = new ArrayList<>();
-  private List<ServiceAtLocationDTO> serviceAtLocations = new ArrayList<>();
-  private List<LanguageDTO> languages = new ArrayList<>();
-  private OrganizationDTO organization;
-  private List<FundingDTO> funding = new ArrayList<>();
-  private List<CostOptionDTO> costOptions = new ArrayList<>();
-  private ProgramDTO program = null;
-  private List<RequiredDocumentDTO> requiredDocuments = new ArrayList<>();
-  private List<ContactDTO> contacts = new ArrayList<>();
-  private List<ServiceCapacityDTO> capacities = new ArrayList<>();
-  private List<AttributeDTO> attributes = new ArrayList<>();
-  private List<MetadataDTO> metadata = new ArrayList<>();
+    private String id;
 
-  public Service toEntity() {
-    return Service.builder()
-            .id(this.id)
-            .name(this.name)
-            .alternateName(this.alternateName)
-            .description(this.description)
-            .url(this.url)
-            .additionalUrls(this.additionalUrls.stream().map(UrlDTO::toEntity).toList())
-            .email(this.email)
-            .status(this.status)
-            .interpretationServices(this.interpretationServices)
-            .applicationProcess(this.applicationProcess)
-            .feesDescription(this.feesDescription)
-            .waitTime(this.waitTime)
-            .fees(this.fees)
-            .accreditations(this.accreditations)
-            .eligibilityDescription(this.eligibilityDescription)
-            .minimumAge(this.minimumAge)
-            .maximumAge(this.maximumAge)
-            .assuredDate(this.assuredDate)
-            .assurerEmail(this.assurerEmail)
-            .licenses(this.licenses)
-            .alert(this.alert)
-            .lastModified(this.lastModified)
-            .phones(this.phones.stream().map(PhoneDTO::toEntity).toList())
-            .schedules(this.schedules.stream().map(ScheduleDTO::toEntity).toList())
-            .serviceAreas(this.serviceAreas.stream().map(ServiceAreaDTO::toEntity).toList())
-            .serviceAtLocations(this.serviceAtLocations.stream().map(ServiceAtLocationDTO::toEntity).toList())
-            .languages(this.languages.stream().map(LanguageDTO::toEntity).toList())
-            .organization(this.organization.toEntity())
-            .funding(this.funding.stream().map(FundingDTO::toEntity).toList())
-            .costOptions(this.costOptions.stream().map(CostOptionDTO::toEntity).toList())
-            .program(this.program != null ? this.program.toEntity() : null)
-            .requiredDocuments(this.requiredDocuments.stream().map(RequiredDocumentDTO::toEntity).toList())
-            .contacts(this.contacts.stream().map(ContactDTO::toEntity).toList())
-            .capacities(this.capacities.stream().map(ServiceCapacityDTO::toEntity).toList())
-            .build();
-  }
+    private String organizationId;
+    private String programId;
+
+    private String name;
+    private String alternateName;
+    private String description;
+    private String url;
+    private String email;
+    private Status status;
+    private String interpretationServices;
+    private String applicationProcess;
+    private String feesDescription;
+    private String waitTime;
+    private String fees;
+    private String accreditations;
+    private String eligibilityDescription;
+    private int minimumAge;
+    private int maximumAge;
+    private LocalDate assuredDate;
+    private String assurerEmail;
+    private String licenses;
+    private String alert;
+    private LocalDateTime lastModified;
+
+    private List<UrlDTO> additionalUrls = new ArrayList<>();
+    private List<PhoneDTO> phones = new ArrayList<>();
+    private List<ScheduleDTO> schedules = new ArrayList<>();
+    private List<ServiceAreaDTO> serviceAreas = new ArrayList<>();
+    private List<ServiceAtLocationDTO> serviceAtLocations = new ArrayList<>();
+    private List<LanguageDTO> languages = new ArrayList<>();
+    private List<FundingDTO> funding = new ArrayList<>();
+    private List<CostOptionDTO> costOptions = new ArrayList<>();
+    private List<RequiredDocumentDTO> requiredDocuments = new ArrayList<>();
+    private List<ContactDTO> contacts = new ArrayList<>();
+    private List<ServiceCapacityDTO> capacities = new ArrayList<>();
+    private List<AttributeDTO> attributes = new ArrayList<>();
+    private List<MetadataDTO> metadata = new ArrayList<>();
+
+    public Service toEntity(Organization organization, Program program) {
+        Service service = Service.builder()
+                .id(this.id == null ? UUID.randomUUID().toString() : this.id)
+                .organization(organization)
+                .program(program)
+                .name(this.name)
+                .alternateName(this.alternateName)
+                .description(this.description)
+                .url(this.url)
+                .email(this.email)
+                .status(this.status)
+                .interpretationServices(this.interpretationServices)
+                .applicationProcess(this.applicationProcess)
+                .feesDescription(this.feesDescription)
+                .waitTime(this.waitTime)
+                .fees(this.fees)
+                .accreditations(this.accreditations)
+                .eligibilityDescription(this.eligibilityDescription)
+                .minimumAge(this.minimumAge)
+                .maximumAge(this.maximumAge)
+                .assuredDate(this.assuredDate)
+                .assurerEmail(this.assurerEmail)
+                .licenses(this.licenses)
+                .alert(this.alert)
+                .lastModified(this.lastModified)
+                .build();
+        service.setAdditionalUrls(this.additionalUrls.stream().map(e -> e.toEntity(null, service)).toList());
+        service.setPhones(this.phones.stream().map(e -> e.toEntity(null, service, null, null, null)).toList());
+        service.setSchedules(this.schedules.stream().map(e -> e.toEntity(service, null, null)).toList());
+        service.setServiceAreas(this.serviceAreas.stream().map(e -> e.toEntity(service, null)).toList());
+        service.setServiceAtLocations(this.serviceAtLocations.stream().map(e -> e.toEntity(service, null)).toList());
+        service.setLanguages(this.languages.stream().map(e -> e.toEntity(service, null, null)).toList());
+        service.setFunding(this.funding.stream().map(e -> e.toEntity(null, service)).toList());
+        service.setCostOptions(this.costOptions.stream().map(e -> e.toEntity(service)).toList());
+        service.setRequiredDocuments(this.requiredDocuments.stream().map(e -> e.toEntity(service)).toList());
+        service.setContacts(this.contacts.stream().map(e -> e.toEntity(null, service, null, null)).toList());
+        service.setCapacities(this.capacities.stream().map(e -> e.toEntity(service, null)).toList());
+        return service;
+    }
 }

--- a/src/main/java/com/sarapis/orservice/dto/TaxonomyDTO.java
+++ b/src/main/java/com/sarapis/orservice/dto/TaxonomyDTO.java
@@ -1,10 +1,12 @@
 package com.sarapis.orservice.dto;
 
 import com.sarapis.orservice.entity.Taxonomy;
+import com.sarapis.orservice.entity.TaxonomyTerm;
 import lombok.*;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 @Getter
 @Setter
@@ -12,20 +14,22 @@ import java.util.List;
 @AllArgsConstructor
 @Builder
 public class TaxonomyDTO {
-  private String id;
-  private String name;
-  private String description;
-  private String uri;
-  private String version;
-  private List<MetadataDTO> metadata = new ArrayList<>();
+    private String id;
 
-  public Taxonomy toEntity() {
-    return Taxonomy.builder()
-            .id(this.id)
-            .name(this.name)
-            .description(this.description)
-            .uri(this.uri)
-            .version(this.version)
-            .build();
-  }
+    private String name;
+    private String description;
+    private String uri;
+    private String version;
+
+    private List<MetadataDTO> metadata = new ArrayList<>();
+
+    public Taxonomy toEntity() {
+        return Taxonomy.builder()
+                .id(this.id == null ? UUID.randomUUID().toString() : this.id)
+                .name(this.name)
+                .description(this.description)
+                .uri(this.uri)
+                .version(this.version)
+                .build();
+    }
 }

--- a/src/main/java/com/sarapis/orservice/dto/TaxonomyTermDTO.java
+++ b/src/main/java/com/sarapis/orservice/dto/TaxonomyTermDTO.java
@@ -1,10 +1,12 @@
 package com.sarapis.orservice.dto;
 
+import com.sarapis.orservice.entity.Attribute;
 import com.sarapis.orservice.entity.TaxonomyTerm;
 import lombok.*;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 @Getter
 @Setter
@@ -12,28 +14,32 @@ import java.util.List;
 @AllArgsConstructor
 @Builder
 public class TaxonomyTermDTO {
-  private String id;
-  private String code;
-  private String name;
-  private String description;
-  private TaxonomyTermDTO parent = null;
-  private String taxonomy;
-  private TaxonomyDTO taxonomyDetail = null;
-  private String language;
-  private String termUri;
-  private List<MetadataDTO> metadata = new ArrayList<>();
+    private String id;
 
-  public TaxonomyTerm toEntity() {
-    return TaxonomyTerm.builder()
-            .id(this.id)
-            .code(this.code)
-            .name(this.name)
-            .description(this.description)
-            .parent(this.parent != null ? this.parent.toEntity() : null)
-            .taxonomy(this.taxonomy)
-            .taxonomyDetail(this.taxonomyDetail != null ? this.taxonomyDetail.toEntity() : null)
-            .language(this.language)
-            .termUri(this.termUri)
-            .build();
-  }
+    private String parentId;
+
+    private String code;
+    private String name;
+    private String description;
+    private String taxonomy;
+    private String language;
+    private String termUri;
+
+    private TaxonomyDTO taxonomyDetail;
+    private List<MetadataDTO> metadata = new ArrayList<>();
+
+    public TaxonomyTerm toEntity(TaxonomyTerm parent) {
+        TaxonomyTerm taxonomyTerm = TaxonomyTerm.builder()
+                .id(this.id == null ? UUID.randomUUID().toString() : this.id)
+                .parent(parent)
+                .code(this.code)
+                .name(this.name)
+                .description(this.description)
+                .taxonomy(this.taxonomy)
+                .language(this.language)
+                .termUri(this.termUri)
+                .build();
+        taxonomyTerm.setTaxonomyDetail(this.taxonomyDetail == null ? null : this.taxonomyDetail.toEntity());
+        return taxonomyTerm;
+    }
 }

--- a/src/main/java/com/sarapis/orservice/dto/UnitDTO.java
+++ b/src/main/java/com/sarapis/orservice/dto/UnitDTO.java
@@ -5,6 +5,7 @@ import lombok.*;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 @Getter
 @Setter
@@ -13,16 +14,18 @@ import java.util.List;
 @Builder
 public class UnitDTO {
     private String id;
+
     private String name;
     private String scheme;
     private String identifier;
     private String uri;
+
     private List<AttributeDTO> attributes = new ArrayList<>();
     private List<MetadataDTO> metadata = new ArrayList<>();
 
     public Unit toEntity() {
         return Unit.builder()
-                .id(this.id)
+                .id(this.id == null ? UUID.randomUUID().toString() : this.id)
                 .name(this.name)
                 .scheme(this.scheme)
                 .identifier(this.identifier)

--- a/src/main/java/com/sarapis/orservice/dto/UrlDTO.java
+++ b/src/main/java/com/sarapis/orservice/dto/UrlDTO.java
@@ -1,10 +1,13 @@
 package com.sarapis.orservice.dto;
 
 import com.sarapis.orservice.entity.Url;
+import com.sarapis.orservice.entity.core.Organization;
+import com.sarapis.orservice.entity.core.Service;
 import lombok.*;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 @Getter
 @Setter
@@ -13,14 +16,21 @@ import java.util.List;
 @Builder
 public class UrlDTO {
     private String id;
+
+    private String organizationId;
+    private String serviceId;
+
     private String label;
     private String url;
+    
     private List<AttributeDTO> attributes = new ArrayList<>();
     private List<MetadataDTO> metadata = new ArrayList<>();
 
-    public Url toEntity() {
+    public Url toEntity(Organization organization, Service service) {
         return Url.builder()
-                .id(this.id)
+                .id(this.id == null ? UUID.randomUUID().toString() : this.id)
+                .organization(organization)
+                .service(service)
                 .label(this.label)
                 .url(this.url)
                 .build();

--- a/src/main/java/com/sarapis/orservice/entity/Accessibility.java
+++ b/src/main/java/com/sarapis/orservice/entity/Accessibility.java
@@ -1,9 +1,9 @@
 package com.sarapis.orservice.entity;
 
 import com.sarapis.orservice.dto.AccessibilityDTO;
+import com.sarapis.orservice.entity.core.Location;
 import jakarta.persistence.*;
 import lombok.*;
-import org.hibernate.annotations.UuidGenerator;
 
 import java.util.ArrayList;
 
@@ -16,10 +16,12 @@ import java.util.ArrayList;
 @Builder
 public class Accessibility {
     @Id
-    @GeneratedValue
-    @UuidGenerator
     @Column(name = "id", nullable = false)
     private String id;
+
+    @ManyToOne
+    @JoinColumn(name = "location_id")
+    private Location location;
 
     @Column(name = "description")
     private String description;
@@ -33,6 +35,7 @@ public class Accessibility {
     public AccessibilityDTO toDTO() {
         return AccessibilityDTO.builder()
                 .id(this.id)
+                .locationId(this.location == null ? null : this.location.getId())
                 .description(this.description)
                 .details(this.details)
                 .url(this.url)

--- a/src/main/java/com/sarapis/orservice/entity/Address.java
+++ b/src/main/java/com/sarapis/orservice/entity/Address.java
@@ -1,9 +1,9 @@
 package com.sarapis.orservice.entity;
 
 import com.sarapis.orservice.dto.AddressDTO;
+import com.sarapis.orservice.entity.core.Location;
 import jakarta.persistence.*;
 import lombok.*;
-import org.hibernate.annotations.UuidGenerator;
 
 import java.util.ArrayList;
 
@@ -16,10 +16,12 @@ import java.util.ArrayList;
 @Builder
 public class Address {
     @Id
-    @GeneratedValue
-    @UuidGenerator
     @Column(name = "id", nullable = false)
     private String id;
+
+    @ManyToOne
+    @JoinColumn(name = "location_id")
+    private Location location;
 
     @Column(name = "attention")
     private String attention;
@@ -52,6 +54,7 @@ public class Address {
     public AddressDTO toDTO() {
         return AddressDTO.builder()
                 .id(this.id)
+                .locationId(this.location == null ? null : this.location.getId())
                 .attention(this.attention)
                 .address_1(this.address_1)
                 .address_2(this.address_2)

--- a/src/main/java/com/sarapis/orservice/entity/AddressType.java
+++ b/src/main/java/com/sarapis/orservice/entity/AddressType.java
@@ -1,7 +1,5 @@
 package com.sarapis.orservice.entity;
 
 public enum AddressType {
-  physical,
-  postal,
-  virtual
+    physical, postal, virtual
 }

--- a/src/main/java/com/sarapis/orservice/entity/Attribute.java
+++ b/src/main/java/com/sarapis/orservice/entity/Attribute.java
@@ -3,7 +3,6 @@ package com.sarapis.orservice.entity;
 import com.sarapis.orservice.dto.AttributeDTO;
 import jakarta.persistence.*;
 import lombok.*;
-import org.hibernate.annotations.UuidGenerator;
 
 import java.util.ArrayList;
 
@@ -16,8 +15,6 @@ import java.util.ArrayList;
 @Builder
 public class Attribute {
     @Id
-    @GeneratedValue
-    @UuidGenerator
     @Column(name = "id", nullable = false)
     private String id;
 
@@ -34,22 +31,23 @@ public class Attribute {
     @Column(name = "value")
     private String value;
 
+    @Column(name = "label")
+    private String label;
+
     @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true, optional = false)
     @JoinColumn(name = "taxonomy_term_id", nullable = false)
     private TaxonomyTerm taxonomyTerm;
-
-    @Column(name = "label")
-    private String label;
 
     public AttributeDTO toDTO() {
         return AttributeDTO.builder()
                 .id(this.id)
                 .linkId(this.linkId)
+                .linkType(this.linkType)
                 .linkEntity(this.linkEntity)
                 .value(this.value)
-                .taxonomyTerm(this.taxonomyTerm != null ? this.taxonomyTerm.toDTO() : null)
-                .metadata(new ArrayList<>())
                 .label(this.label)
+                .taxonomyTerm(this.taxonomyTerm.toDTO())
+                .metadata(new ArrayList<>())
                 .build();
     }
 }

--- a/src/main/java/com/sarapis/orservice/entity/Contact.java
+++ b/src/main/java/com/sarapis/orservice/entity/Contact.java
@@ -1,9 +1,12 @@
 package com.sarapis.orservice.entity;
 
 import com.sarapis.orservice.dto.ContactDTO;
+import com.sarapis.orservice.entity.core.Location;
+import com.sarapis.orservice.entity.core.Organization;
+import com.sarapis.orservice.entity.core.Service;
+import com.sarapis.orservice.entity.core.ServiceAtLocation;
 import jakarta.persistence.*;
 import lombok.*;
-import org.hibernate.annotations.UuidGenerator;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -17,10 +20,24 @@ import java.util.List;
 @Builder
 public class Contact {
     @Id
-    @GeneratedValue
-    @UuidGenerator
     @Column(name = "id", nullable = false)
     private String id;
+
+    @ManyToOne
+    @JoinColumn(name = "organization_id")
+    private Organization organization;
+
+    @ManyToOne
+    @JoinColumn(name = "service_id")
+    private Service service;
+
+    @ManyToOne
+    @JoinColumn(name = "service_at_location_id")
+    private ServiceAtLocation serviceAtLocation;
+
+    @ManyToOne
+    @JoinColumn(name = "location_id")
+    private Location location;
 
     @Column(name = "name")
     private String name;
@@ -34,13 +51,24 @@ public class Contact {
     @Column(name = "email")
     private String email;
 
-    @OneToMany(cascade = CascadeType.PERSIST)
-    @JoinColumn(name = "contact_id")
+    @OneToMany(cascade = { CascadeType.PERSIST, CascadeType.MERGE }, mappedBy = "contact")
     private List<Phone> phones = new ArrayList<>();
+
+    @PreRemove
+    public void preRemove() {
+        // Sets optional foreign keys to null since we're not using CascadeType.ALL
+        for (Phone phone : phones) {
+            phone.setContact(null);
+        }
+    }
 
     public ContactDTO toDTO() {
         return ContactDTO.builder()
                 .id(this.id)
+                .organizationId(this.organization == null ? null : this.organization.getId())
+                .serviceId(this.service == null ? null : this.service.getId())
+                .serviceAtLocationId(this.serviceAtLocation == null ? null : this.serviceAtLocation.getId())
+                .locationId(this.location == null ? null : this.location.getId())
                 .name(this.name)
                 .title(this.title)
                 .department(this.department)

--- a/src/main/java/com/sarapis/orservice/entity/CostOption.java
+++ b/src/main/java/com/sarapis/orservice/entity/CostOption.java
@@ -1,9 +1,10 @@
 package com.sarapis.orservice.entity;
 
 import com.sarapis.orservice.dto.CostOptionDTO;
+import com.sarapis.orservice.entity.core.Organization;
+import com.sarapis.orservice.entity.core.Service;
 import jakarta.persistence.*;
 import lombok.*;
-import org.hibernate.annotations.UuidGenerator;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -17,10 +18,12 @@ import java.util.ArrayList;
 @Builder
 public class CostOption {
     @Id
-    @GeneratedValue
-    @UuidGenerator
     @Column(name = "id", nullable = false)
     private String id;
+
+    @ManyToOne
+    @JoinColumn(name = "service_id", nullable = false)
+    private Service service;
 
     @Column(name = "valid_from")
     private LocalDate validFrom;
@@ -43,6 +46,7 @@ public class CostOption {
     public CostOptionDTO toDTO() {
         return CostOptionDTO.builder()
                 .id(this.id)
+                .serviceId(this.service.getId())
                 .validFrom(this.validFrom)
                 .validTo(this.validTo)
                 .option(this.option)

--- a/src/main/java/com/sarapis/orservice/entity/ExtentType.java
+++ b/src/main/java/com/sarapis/orservice/entity/ExtentType.java
@@ -1,8 +1,5 @@
 package com.sarapis.orservice.entity;
 
 public enum ExtentType {
-    geojson,
-    topojson,
-    kml,
-    text
+    geojson, topojson, kml, text
 }

--- a/src/main/java/com/sarapis/orservice/entity/Freq.java
+++ b/src/main/java/com/sarapis/orservice/entity/Freq.java
@@ -1,6 +1,5 @@
 package com.sarapis.orservice.entity;
 
 public enum Freq {
-  WEEKLY,
-  MONTHLY
+    WEEKLY, MONTHLY
 }

--- a/src/main/java/com/sarapis/orservice/entity/Funding.java
+++ b/src/main/java/com/sarapis/orservice/entity/Funding.java
@@ -1,9 +1,10 @@
 package com.sarapis.orservice.entity;
 
 import com.sarapis.orservice.dto.FundingDTO;
+import com.sarapis.orservice.entity.core.Organization;
+import com.sarapis.orservice.entity.core.Service;
 import jakarta.persistence.*;
 import lombok.*;
-import org.hibernate.annotations.UuidGenerator;
 
 import java.util.ArrayList;
 
@@ -16,10 +17,16 @@ import java.util.ArrayList;
 @Builder
 public class Funding {
     @Id
-    @GeneratedValue
-    @UuidGenerator
     @Column(name = "id", nullable = false)
     private String id;
+
+    @ManyToOne
+    @JoinColumn(name = "organization_id")
+    private Organization organization;
+
+    @ManyToOne
+    @JoinColumn(name = "service_id")
+    private Service service;
 
     @Column(name = "source")
     private String source;
@@ -27,6 +34,8 @@ public class Funding {
     public FundingDTO toDTO() {
         return FundingDTO.builder()
                 .id(this.id)
+                .organizationId(this.organization == null ? null : this.organization.getId())
+                .serviceId(this.service == null ? null : this.service.getId())
                 .source(this.source)
                 .attributes(new ArrayList<>())
                 .metadata(new ArrayList<>())

--- a/src/main/java/com/sarapis/orservice/entity/Language.java
+++ b/src/main/java/com/sarapis/orservice/entity/Language.java
@@ -1,9 +1,10 @@
 package com.sarapis.orservice.entity;
 
 import com.sarapis.orservice.dto.LanguageDTO;
+import com.sarapis.orservice.entity.core.Location;
+import com.sarapis.orservice.entity.core.Service;
 import jakarta.persistence.*;
 import lombok.*;
-import org.hibernate.annotations.UuidGenerator;
 
 import java.util.ArrayList;
 
@@ -16,10 +17,20 @@ import java.util.ArrayList;
 @Builder
 public class Language {
     @Id
-    @GeneratedValue
-    @UuidGenerator
     @Column(name = "id", nullable = false)
     private String id;
+
+    @ManyToOne
+    @JoinColumn(name = "service_id")
+    private Service service;
+
+    @ManyToOne
+    @JoinColumn(name = "location_id")
+    private Location location;
+
+    @ManyToOne
+    @JoinColumn(name = "phone_id")
+    private Phone phone;
 
     @Column(name = "name")
     private String name;
@@ -33,6 +44,9 @@ public class Language {
     public LanguageDTO toDTO() {
         return LanguageDTO.builder()
                 .id(this.id)
+                .serviceId(this.service == null ? null : this.service.getId())
+                .locationId(this.location == null ? null : this.location.getId())
+                .phoneId(this.phone == null ? null : this.phone.getId())
                 .name(this.name)
                 .code(this.code)
                 .note(this.note)

--- a/src/main/java/com/sarapis/orservice/entity/LinkEntity.java
+++ b/src/main/java/com/sarapis/orservice/entity/LinkEntity.java
@@ -1,24 +1,7 @@
 package com.sarapis.orservice.entity;
 
 public enum LinkEntity {
-    organization,
-    service,
-    location,
-    service_at_location,
-    address,
-    phone,
-    schedule,
-    service_area,
-    language,
-    funding,
-    accessibility,
-    cost_option,
-    program,
-    required_document,
-    contact,
-    organization_identifier,
-    unit,
-    service_capacity,
-    url,
-    meta_table_description
+    organization, service, location, service_at_location, address, phone, schedule, service_area, language, funding,
+    accessibility, cost_option, program, required_document, contact, organization_identifier, unit, service_capacity,
+    url, meta_table_description
 }

--- a/src/main/java/com/sarapis/orservice/entity/MetaTableDescription.java
+++ b/src/main/java/com/sarapis/orservice/entity/MetaTableDescription.java
@@ -1,9 +1,11 @@
 package com.sarapis.orservice.entity;
 
 import com.sarapis.orservice.dto.MetaTableDescriptionDTO;
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import lombok.*;
-import org.hibernate.annotations.UuidGenerator;
 
 import java.util.ArrayList;
 
@@ -16,8 +18,6 @@ import java.util.ArrayList;
 @Builder
 public class MetaTableDescription {
     @Id
-    @GeneratedValue
-    @UuidGenerator
     @Column(name = "id", nullable = false)
     private String id;
 

--- a/src/main/java/com/sarapis/orservice/entity/Metadata.java
+++ b/src/main/java/com/sarapis/orservice/entity/Metadata.java
@@ -3,7 +3,6 @@ package com.sarapis.orservice.entity;
 import com.sarapis.orservice.dto.MetadataDTO;
 import jakarta.persistence.*;
 import lombok.*;
-import org.hibernate.annotations.UuidGenerator;
 
 import java.time.LocalDate;
 
@@ -16,8 +15,6 @@ import java.time.LocalDate;
 @Builder
 public class Metadata {
     @Id
-    @GeneratedValue
-    @UuidGenerator
     @Column(name = "id", nullable = false)
     private String id;
 

--- a/src/main/java/com/sarapis/orservice/entity/OrganizationIdentifier.java
+++ b/src/main/java/com/sarapis/orservice/entity/OrganizationIdentifier.java
@@ -1,9 +1,9 @@
 package com.sarapis.orservice.entity;
 
 import com.sarapis.orservice.dto.OrganizationIdentifierDTO;
+import com.sarapis.orservice.entity.core.Organization;
 import jakarta.persistence.*;
 import lombok.*;
-import org.hibernate.annotations.UuidGenerator;
 
 import java.util.ArrayList;
 
@@ -16,10 +16,12 @@ import java.util.ArrayList;
 @Builder
 public class OrganizationIdentifier {
     @Id
-    @GeneratedValue
-    @UuidGenerator
     @Column(name = "id", nullable = false)
     private String id;
+
+    @ManyToOne
+    @JoinColumn(name = "organization_id", nullable = false)
+    private Organization organization;
 
     @Column(name = "identifier_scheme")
     private String identifierScheme;
@@ -33,6 +35,7 @@ public class OrganizationIdentifier {
     public OrganizationIdentifierDTO toDTO() {
         return OrganizationIdentifierDTO.builder()
                 .id(this.id)
+                .organizationId(this.organization.getId())
                 .identifierScheme(this.identifierScheme)
                 .identifierType(this.identifierType)
                 .identifier(this.identifier)

--- a/src/main/java/com/sarapis/orservice/entity/Phone.java
+++ b/src/main/java/com/sarapis/orservice/entity/Phone.java
@@ -1,6 +1,10 @@
 package com.sarapis.orservice.entity;
 
 import com.sarapis.orservice.dto.PhoneDTO;
+import com.sarapis.orservice.entity.core.Location;
+import com.sarapis.orservice.entity.core.Organization;
+import com.sarapis.orservice.entity.core.Service;
+import com.sarapis.orservice.entity.core.ServiceAtLocation;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.UuidGenerator;
@@ -22,6 +26,26 @@ public class Phone {
     @Column(name = "id", nullable = false)
     private String id;
 
+    @ManyToOne
+    @JoinColumn(name = "location_id")
+    private Location location;
+
+    @ManyToOne
+    @JoinColumn(name = "service_id")
+    private Service service;
+
+    @ManyToOne
+    @JoinColumn(name = "organization_id")
+    private Organization organization;
+
+    @ManyToOne
+    @JoinColumn(name = "contact_id")
+    private Contact contact;
+
+    @ManyToOne
+    @JoinColumn(name = "service_at_location_id")
+    private ServiceAtLocation serviceAtLocation;
+
     @Column(name = "number", nullable = false)
     private String number;
 
@@ -34,13 +58,25 @@ public class Phone {
     @Column(name = "description")
     private String description;
 
-    @OneToMany(cascade = CascadeType.PERSIST)
-    @JoinColumn(name = "phone_id")
+    @OneToMany(cascade = {CascadeType.PERSIST, CascadeType.MERGE}, mappedBy = "phone")
     private List<Language> languages = new ArrayList<>();
+
+    @PreRemove
+    public void preRemove() {
+        // Sets optional foreign keys to null since we're not using CascadeType.ALL
+        for (Language language : languages) {
+            language.setPhone(null);
+        }
+    }
 
     public PhoneDTO toDTO() {
         return PhoneDTO.builder()
                 .id(this.id)
+                .locationId(this.location == null ? null : this.location.getId())
+                .serviceId(this.service == null ? null : this.service.getId())
+                .organizationId(this.organization == null ? null : this.organization.getId())
+                .contactId(this.contact == null ? null : this.contact.getId())
+                .serviceAtLocationId(this.serviceAtLocation == null ? null : this.serviceAtLocation.getId())
                 .number(this.number)
                 .extension(this.extension)
                 .type(this.type)

--- a/src/main/java/com/sarapis/orservice/entity/Program.java
+++ b/src/main/java/com/sarapis/orservice/entity/Program.java
@@ -1,9 +1,9 @@
 package com.sarapis.orservice.entity;
 
 import com.sarapis.orservice.dto.ProgramDTO;
+import com.sarapis.orservice.entity.core.Organization;
 import jakarta.persistence.*;
 import lombok.*;
-import org.hibernate.annotations.UuidGenerator;
 
 import java.util.ArrayList;
 
@@ -16,10 +16,12 @@ import java.util.ArrayList;
 @Builder
 public class Program {
     @Id
-    @GeneratedValue
-    @UuidGenerator
     @Column(name = "id", nullable = false)
     private String id;
+
+    @ManyToOne
+    @JoinColumn(name = "organization_id", nullable = false, unique = true)
+    private Organization organization;
 
     @Column(name = "name", nullable = false)
     private String name;
@@ -33,6 +35,7 @@ public class Program {
     public ProgramDTO toDTO() {
         return ProgramDTO.builder()
                 .id(this.id)
+                .organizationId(this.organization.getId())
                 .name(this.name)
                 .alternateName(this.alternateName)
                 .description(this.description)

--- a/src/main/java/com/sarapis/orservice/entity/RequiredDocument.java
+++ b/src/main/java/com/sarapis/orservice/entity/RequiredDocument.java
@@ -1,9 +1,9 @@
 package com.sarapis.orservice.entity;
 
 import com.sarapis.orservice.dto.RequiredDocumentDTO;
+import com.sarapis.orservice.entity.core.Service;
 import jakarta.persistence.*;
 import lombok.*;
-import org.hibernate.annotations.UuidGenerator;
 
 import java.util.ArrayList;
 
@@ -16,10 +16,12 @@ import java.util.ArrayList;
 @Builder
 public class RequiredDocument {
     @Id
-    @GeneratedValue
-    @UuidGenerator
     @Column(name = "id", nullable = false)
     private String id;
+
+    @ManyToOne
+    @JoinColumn(name = "service_id")
+    private Service service;
 
     @Column(name = "document")
     private String document;
@@ -30,6 +32,7 @@ public class RequiredDocument {
     public RequiredDocumentDTO toDTO() {
         return RequiredDocumentDTO.builder()
                 .id(this.id)
+                .serviceId(this.service == null ? null : this.service.getId())
                 .document(this.document)
                 .uri(this.uri)
                 .attributes(new ArrayList<>())

--- a/src/main/java/com/sarapis/orservice/entity/ResourceType.java
+++ b/src/main/java/com/sarapis/orservice/entity/ResourceType.java
@@ -1,27 +1,7 @@
 package com.sarapis.orservice.entity;
 
 public enum ResourceType {
-  organization,
-  service,
-  location,
-  service_at_location,
-  address,
-  phone,
-  schedule,
-  service_area,
-  language,
-  funding,
-  accessibility,
-  cost_option,
-  program,
-  required_document,
-  contact,
-  organization_identifier,
-  unit,
-  service_capacity,
-  attribute,
-  url,
-  meta_table_description,
-  taxonomy,
-  taxonomy_term
+    organization, service, location, service_at_location, address, phone, schedule, service_area, language, funding,
+    accessibility, cost_option, program, required_document, contact, organization_identifier, unit, service_capacity,
+    attribute, url, meta_table_description, taxonomy, taxonomy_term
 }

--- a/src/main/java/com/sarapis/orservice/entity/Schedule.java
+++ b/src/main/java/com/sarapis/orservice/entity/Schedule.java
@@ -1,9 +1,11 @@
 package com.sarapis.orservice.entity;
 
 import com.sarapis.orservice.dto.ScheduleDTO;
+import com.sarapis.orservice.entity.core.Location;
+import com.sarapis.orservice.entity.core.Service;
+import com.sarapis.orservice.entity.core.ServiceAtLocation;
 import jakarta.persistence.*;
 import lombok.*;
-import org.hibernate.annotations.UuidGenerator;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -18,10 +20,20 @@ import java.util.ArrayList;
 @Builder
 public class Schedule {
     @Id
-    @GeneratedValue
-    @UuidGenerator
     @Column(name = "id", nullable = false)
     private String id;
+
+    @ManyToOne
+    @JoinColumn(name = "service_id")
+    private Service service;
+
+    @ManyToOne
+    @JoinColumn(name = "location_id")
+    private Location location;
+
+    @ManyToOne
+    @JoinColumn(name = "service_at_location_id")
+    private ServiceAtLocation serviceAtLocation;
 
     @Column(name = "valid_from")
     private LocalDate validFrom;
@@ -85,6 +97,9 @@ public class Schedule {
     public ScheduleDTO toDTO() {
         return ScheduleDTO.builder()
                 .id(this.id)
+                .serviceId(this.service == null ? null : this.service.getId())
+                .locationId(this.location == null ? null : this.location.getId())
+                .serviceAtLocationId(this.serviceAtLocation == null ? null : this.serviceAtLocation.getId())
                 .validFrom(this.validFrom)
                 .validTo(this.validTo)
                 .dtStart(this.dtStart)

--- a/src/main/java/com/sarapis/orservice/entity/ServiceArea.java
+++ b/src/main/java/com/sarapis/orservice/entity/ServiceArea.java
@@ -1,9 +1,10 @@
 package com.sarapis.orservice.entity;
 
 import com.sarapis.orservice.dto.ServiceAreaDTO;
+import com.sarapis.orservice.entity.core.Service;
+import com.sarapis.orservice.entity.core.ServiceAtLocation;
 import jakarta.persistence.*;
 import lombok.*;
-import org.hibernate.annotations.UuidGenerator;
 
 import java.util.ArrayList;
 
@@ -16,10 +17,16 @@ import java.util.ArrayList;
 @Builder
 public class ServiceArea {
     @Id
-    @GeneratedValue
-    @UuidGenerator
     @Column(name = "id", nullable = false)
     private String id;
+
+    @ManyToOne
+    @JoinColumn(name = "service_id")
+    private Service service;
+
+    @ManyToOne
+    @JoinColumn(name = "service_at_location_id")
+    private ServiceAtLocation serviceAtLocation;
 
     @Column(name = "name")
     private String name;
@@ -40,6 +47,8 @@ public class ServiceArea {
     public ServiceAreaDTO toDTO() {
         return ServiceAreaDTO.builder()
                 .id(this.id)
+                .serviceId(this.service == null ? null : this.service.getId())
+                .serviceAtLocationId(this.serviceAtLocation == null ? null : this.serviceAtLocation.getId())
                 .name(this.name)
                 .description(this.description)
                 .extent(this.extent)

--- a/src/main/java/com/sarapis/orservice/entity/ServiceCapacity.java
+++ b/src/main/java/com/sarapis/orservice/entity/ServiceCapacity.java
@@ -1,9 +1,9 @@
 package com.sarapis.orservice.entity;
 
 import com.sarapis.orservice.dto.ServiceCapacityDTO;
+import com.sarapis.orservice.entity.core.Service;
 import jakarta.persistence.*;
 import lombok.*;
-import org.hibernate.annotations.UuidGenerator;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -17,14 +17,16 @@ import java.util.ArrayList;
 @Builder
 public class ServiceCapacity {
     @Id
-    @GeneratedValue
-    @UuidGenerator
     @Column(name = "id", nullable = false)
     private String id;
 
-    @OneToOne
-    @JoinColumn(name = "unit_id")
-    private Unit unit = null;
+    @ManyToOne
+    @JoinColumn(name = "service_id", nullable = false)
+    private Service service;
+
+    @OneToOne(orphanRemoval = true, optional = false)
+    @JoinColumn(name = "unit_id", nullable = false)
+    private Unit unit;
 
     @Column(name = "available", nullable = false)
     private int available;
@@ -41,7 +43,8 @@ public class ServiceCapacity {
     public ServiceCapacityDTO toDTO() {
         return ServiceCapacityDTO.builder()
                 .id(this.id)
-                .unit(this.unit != null ? this.unit.toDTO() : null)
+                .serviceId(this.service.getId())
+                .unitId(this.unit.getId())
                 .available(this.available)
                 .maximum(this.maximum)
                 .description(this.description)

--- a/src/main/java/com/sarapis/orservice/entity/Taxonomy.java
+++ b/src/main/java/com/sarapis/orservice/entity/Taxonomy.java
@@ -3,7 +3,6 @@ package com.sarapis.orservice.entity;
 import com.sarapis.orservice.dto.TaxonomyDTO;
 import jakarta.persistence.*;
 import lombok.*;
-import org.hibernate.annotations.UuidGenerator;
 
 import java.util.ArrayList;
 
@@ -16,8 +15,6 @@ import java.util.ArrayList;
 @Builder
 public class Taxonomy {
     @Id
-    @GeneratedValue
-    @UuidGenerator
     @Column(name = "id", nullable = false)
     private String id;
 

--- a/src/main/java/com/sarapis/orservice/entity/Unit.java
+++ b/src/main/java/com/sarapis/orservice/entity/Unit.java
@@ -3,7 +3,6 @@ package com.sarapis.orservice.entity;
 import com.sarapis.orservice.dto.UnitDTO;
 import jakarta.persistence.*;
 import lombok.*;
-import org.hibernate.annotations.UuidGenerator;
 
 import java.util.ArrayList;
 
@@ -16,8 +15,6 @@ import java.util.ArrayList;
 @Builder
 public class Unit {
     @Id
-    @GeneratedValue
-    @UuidGenerator
     @Column(name = "id", nullable = false)
     private String id;
 
@@ -32,6 +29,9 @@ public class Unit {
 
     @Column(name = "uri")
     private String uri;
+
+    @OneToOne(cascade = CascadeType.REMOVE, mappedBy = "unit")
+    private ServiceCapacity serviceCapacity;
 
     public UnitDTO toDTO() {
         return UnitDTO.builder()

--- a/src/main/java/com/sarapis/orservice/entity/Url.java
+++ b/src/main/java/com/sarapis/orservice/entity/Url.java
@@ -1,9 +1,10 @@
 package com.sarapis.orservice.entity;
 
 import com.sarapis.orservice.dto.UrlDTO;
+import com.sarapis.orservice.entity.core.Organization;
+import com.sarapis.orservice.entity.core.Service;
 import jakarta.persistence.*;
 import lombok.*;
-import org.hibernate.annotations.UuidGenerator;
 
 import java.util.ArrayList;
 
@@ -16,10 +17,16 @@ import java.util.ArrayList;
 @Builder
 public class Url {
     @Id
-    @GeneratedValue
-    @UuidGenerator
     @Column(name = "id", nullable = false)
     private String id;
+
+    @ManyToOne
+    @JoinColumn(name = "organization_id")
+    private Organization organization;
+
+    @ManyToOne
+    @JoinColumn(name = "service_id")
+    private Service service;
 
     @Column(name = "label")
     private String label;
@@ -30,6 +37,8 @@ public class Url {
     public UrlDTO toDTO() {
         return UrlDTO.builder()
                 .id(this.id)
+                .organizationId(this.organization == null ? null : this.organization.getId())
+                .serviceId(this.service == null ? null : this.service.getId())
                 .label(this.label)
                 .url(this.url)
                 .attributes(new ArrayList<>())

--- a/src/main/java/com/sarapis/orservice/entity/WkSt.java
+++ b/src/main/java/com/sarapis/orservice/entity/WkSt.java
@@ -1,11 +1,5 @@
 package com.sarapis.orservice.entity;
 
 public enum WkSt {
-  MO,
-  TU,
-  WE,
-  TH,
-  FR,
-  SA,
-  SU
+    MO, TU, WE, TH, FR, SA, SU
 }

--- a/src/main/java/com/sarapis/orservice/entity/core/LocationType.java
+++ b/src/main/java/com/sarapis/orservice/entity/core/LocationType.java
@@ -1,7 +1,5 @@
 package com.sarapis.orservice.entity.core;
 
 public enum LocationType {
-  physical,
-  postal,
-  virtual
+    physical, postal, virtual
 }

--- a/src/main/java/com/sarapis/orservice/entity/core/Service.java
+++ b/src/main/java/com/sarapis/orservice/entity/core/Service.java
@@ -5,7 +5,7 @@ import com.sarapis.orservice.entity.*;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.OnDelete;
-import org.hibernate.annotations.UuidGenerator;
+import org.hibernate.annotations.OnDeleteAction;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -21,10 +21,17 @@ import java.util.List;
 @Builder
 public class Service {
     @Id
-    @GeneratedValue
-    @UuidGenerator
     @Column(name = "id", nullable = false)
     private String id;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "organization_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private Organization organization;
+
+    @ManyToOne
+    @JoinColumn(name = "program_id")
+    private Program program = null;
 
     @Column(name = "name", nullable = false)
     private String name;
@@ -37,10 +44,6 @@ public class Service {
 
     @Column(name = "url")
     private String url;
-
-    @OneToMany(cascade = CascadeType.PERSIST)
-    @JoinColumn(name = "service_id")
-    private List<Url> additionalUrls = new ArrayList<>();
 
     @Column(name = "email")
     private String email;
@@ -94,58 +97,70 @@ public class Service {
     @Column(name = "last_modified")
     private LocalDateTime lastModified;
 
-    @OneToMany(cascade = CascadeType.PERSIST)
-    @JoinColumn(name = "service_id")
+    @OneToMany(cascade = {CascadeType.PERSIST, CascadeType.MERGE}, mappedBy = "service")
+    private List<Url> additionalUrls = new ArrayList<>();
+
+    @OneToMany(cascade = {CascadeType.PERSIST, CascadeType.MERGE}, mappedBy = "service")
     private List<Phone> phones = new ArrayList<>();
 
-    @OneToMany(cascade = CascadeType.PERSIST)
-    @JoinColumn(name = "service_id")
+    @OneToMany(cascade = {CascadeType.PERSIST, CascadeType.MERGE}, mappedBy = "service")
     private List<Schedule> schedules = new ArrayList<>();
 
-    @OneToMany(cascade = CascadeType.PERSIST)
-    @JoinColumn(name = "service_id")
+    @OneToMany(cascade = {CascadeType.PERSIST, CascadeType.MERGE}, mappedBy = "service")
     private List<ServiceArea> serviceAreas = new ArrayList<>();
 
-    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
-    @JoinColumn(name = "service_id", nullable = false)
+    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true, mappedBy = "service")
     private List<ServiceAtLocation> serviceAtLocations = new ArrayList<>();
 
-    @OneToMany(cascade = CascadeType.PERSIST)
-    @JoinColumn(name = "service_id")
+    @OneToMany(cascade = {CascadeType.PERSIST, CascadeType.MERGE}, mappedBy = "service")
     private List<Language> languages = new ArrayList<>();
 
-    // On Organization delete, all related Services should be deleted.
-    @ManyToOne(optional = false)
-    @JoinColumn(name = "organization_id", nullable = false)
-    private Organization organization;
-
-    @OneToMany(cascade = CascadeType.PERSIST)
-    @JoinColumn(name = "service_id")
+    @OneToMany(cascade = {CascadeType.PERSIST, CascadeType.MERGE}, mappedBy = "service")
     private List<Funding> funding = new ArrayList<>();
 
-    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
-    @JoinColumn(name = "service_id", nullable = false)
+    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true, mappedBy = "service")
     private List<CostOption> costOptions = new ArrayList<>();
 
-    @ManyToOne
-    @JoinColumn(name = "program_id")
-    private Program program = null;
-
-    @OneToMany(cascade = CascadeType.PERSIST)
-    @JoinColumn(name = "service_id")
+    @OneToMany(cascade = {CascadeType.PERSIST, CascadeType.MERGE}, mappedBy = "service")
     private List<RequiredDocument> requiredDocuments = new ArrayList<>();
 
-    @OneToMany(cascade = CascadeType.PERSIST)
-    @JoinColumn(name = "service_id")
+    @OneToMany(cascade = {CascadeType.PERSIST, CascadeType.MERGE}, mappedBy = "service")
     private List<Contact> contacts = new ArrayList<>();
 
-    @OneToMany(cascade = CascadeType.PERSIST)
-    @JoinColumn(name = "service_id")
+    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true, mappedBy = "service")
     private List<ServiceCapacity> capacities = new ArrayList<>();
+
+    @PreRemove
+    public void preRemove() {
+        // Sets optional foreign keys to null since we're not using CascadeType.ALL
+        for (Url url : additionalUrls) {
+            url.setService(null);
+        }
+        for (Phone phone : phones) {
+            phone.setService(null);
+        }
+        for (Schedule schedule : schedules) {
+            schedule.setService(null);
+        }
+        for (ServiceArea serviceArea : serviceAreas) {
+            serviceArea.setService(null);
+        }
+        for (Language language : languages) {
+            language.setService(null);
+        }
+        for (RequiredDocument requiredDocument : requiredDocuments) {
+            requiredDocument.setService(null);
+        }
+        for (Contact contact : contacts) {
+            contact.setService(null);
+        }
+    }
 
     public ServiceDTO toDTO() {
         return ServiceDTO.builder()
                 .id(this.id)
+                .organizationId(this.organization.getId())
+                .programId(this.program == null ? null : this.program.getId())
                 .name(this.name)
                 .alternateName(this.alternateName)
                 .description(this.description)
@@ -172,10 +187,8 @@ public class Service {
                 .serviceAreas(this.serviceAreas.stream().map(ServiceArea::toDTO).toList())
                 .serviceAtLocations(this.serviceAtLocations.stream().map(ServiceAtLocation::toDTO).toList())
                 .languages(this.languages.stream().map(Language::toDTO).toList())
-                .organization(this.organization != null ? organization.toDTO() : null)
                 .funding(this.funding.stream().map(Funding::toDTO).toList())
                 .costOptions(this.costOptions.stream().map(CostOption::toDTO).toList())
-                .program(this.program != null ? program.toDTO() : null)
                 .requiredDocuments(this.requiredDocuments.stream().map(RequiredDocument::toDTO).toList())
                 .contacts(this.contacts.stream().map(Contact::toDTO).toList())
                 .capacities(this.capacities.stream().map(ServiceCapacity::toDTO).toList())

--- a/src/main/java/com/sarapis/orservice/entity/core/ServiceAtLocation.java
+++ b/src/main/java/com/sarapis/orservice/entity/core/ServiceAtLocation.java
@@ -7,7 +7,6 @@ import com.sarapis.orservice.entity.Schedule;
 import com.sarapis.orservice.entity.ServiceArea;
 import jakarta.persistence.*;
 import lombok.*;
-import org.hibernate.annotations.UuidGenerator;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -21,37 +20,54 @@ import java.util.List;
 @Builder
 public class ServiceAtLocation {
     @Id
-    @GeneratedValue
-    @UuidGenerator
     @Column(name = "id", nullable = false)
     private String id;
 
-    @Column(name = "description")
-    private String description;
-
-    @OneToMany(cascade = CascadeType.PERSIST)
-    @JoinColumn(name = "service_at_location_id")
-    private List<ServiceArea> serviceAreas = new ArrayList<>();
-
-    @OneToMany(cascade = CascadeType.PERSIST)
-    @JoinColumn(name = "service_at_location_id")
-    private List<Contact> contacts = new ArrayList<>();
-
-    @OneToMany(cascade = CascadeType.PERSIST)
-    @JoinColumn(name = "service_at_location_id")
-    private List<Phone> phones = new ArrayList<>();
-
-    @OneToMany(cascade = CascadeType.PERSIST)
-    @JoinColumn(name = "service_at_location_id")
-    private List<Schedule> schedules = new ArrayList<>();
+    @ManyToOne
+    @JoinColumn(name = "service_id", nullable = false)
+    private Service service;
 
     @OneToOne(orphanRemoval = true, optional = false)
     @JoinColumn(name = "location_id", nullable = false)
     private Location location;
 
+    @Column(name = "description")
+    private String description;
+
+    @OneToMany(cascade = {CascadeType.PERSIST, CascadeType.MERGE}, mappedBy = "serviceAtLocation")
+    private List<ServiceArea> serviceAreas = new ArrayList<>();
+
+    @OneToMany(cascade = {CascadeType.PERSIST, CascadeType.MERGE}, mappedBy = "serviceAtLocation")
+    private List<Contact> contacts = new ArrayList<>();
+
+    @OneToMany(cascade = {CascadeType.PERSIST, CascadeType.MERGE}, mappedBy = "serviceAtLocation")
+    private List<Phone> phones = new ArrayList<>();
+
+    @OneToMany(cascade = {CascadeType.PERSIST, CascadeType.MERGE}, mappedBy = "serviceAtLocation")
+    private List<Schedule> schedules = new ArrayList<>();
+
+    @PreRemove
+    public void preRemove() {
+        // Sets optional foreign keys to null since we're not using CascadeType.ALL
+        for (ServiceArea serviceArea : serviceAreas) {
+            serviceArea.setServiceAtLocation(null);
+        }
+        for (Contact contact : contacts) {
+            contact.setServiceAtLocation(null);
+        }
+        for (Phone phone : phones) {
+            phone.setServiceAtLocation(null);
+        }
+        for (Schedule schedule : schedules) {
+            schedule.setServiceAtLocation(null);
+        }
+    }
+
     public ServiceAtLocationDTO toDTO() {
         return ServiceAtLocationDTO.builder()
                 .id(this.id)
+                .serviceId(this.service.getId())
+                .locationId(this.location.getId())
                 .description(this.description)
                 .serviceAreas(this.serviceAreas.stream().map(ServiceArea::toDTO).toList())
                 .contacts(this.contacts.stream().map(Contact::toDTO).toList())

--- a/src/main/java/com/sarapis/orservice/entity/core/Status.java
+++ b/src/main/java/com/sarapis/orservice/entity/core/Status.java
@@ -1,8 +1,5 @@
 package com.sarapis.orservice.entity.core;
 
 public enum Status {
-  active,
-  inactive,
-  defunct,
-  temporarily_closed
+    active, inactive, defunct, temporarily_closed
 }

--- a/src/main/java/com/sarapis/orservice/repository/AccessibilityRepository.java
+++ b/src/main/java/com/sarapis/orservice/repository/AccessibilityRepository.java
@@ -1,31 +1,9 @@
 package com.sarapis.orservice.repository;
 
 import com.sarapis.orservice.entity.Accessibility;
-import com.sarapis.orservice.entity.Attribute;
-import com.sarapis.orservice.entity.Metadata;
-import jakarta.transaction.Transactional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
-
-import java.util.List;
 
 @Repository
 public interface AccessibilityRepository extends JpaRepository<Accessibility, String> {
-    @Query("SELECT new Attribute(id, linkId, linkType, linkEntity, value, taxonomyTerm, label) FROM Attribute WHERE linkId = ?1")
-    List<Attribute> getAttributes(String organizationId);
-
-    @Query("SELECT new Metadata(id, resourceId, resourceType, lastActionDate, lastActionType, fieldName, previousValue, replacementValue, updatedBy) FROM Metadata WHERE resourceId = ?1")
-    List<Metadata> getMetadata(String organizationId);
-
-    @Modifying
-    @Transactional
-    @Query("DELETE FROM Attribute WHERE linkId = ?1")
-    void deleteAttributes(String organizationId);
-
-    @Modifying
-    @Transactional
-    @Query("DELETE FROM Metadata WHERE resourceId = ?1")
-    void deleteMetadata(String organizationId);
 }

--- a/src/main/java/com/sarapis/orservice/repository/AddressRepository.java
+++ b/src/main/java/com/sarapis/orservice/repository/AddressRepository.java
@@ -1,31 +1,9 @@
 package com.sarapis.orservice.repository;
 
 import com.sarapis.orservice.entity.Address;
-import com.sarapis.orservice.entity.Attribute;
-import com.sarapis.orservice.entity.Metadata;
-import jakarta.transaction.Transactional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
-
-import java.util.List;
 
 @Repository
 public interface AddressRepository extends JpaRepository<Address, String> {
-    @Query("SELECT new Attribute(id, linkId, linkType, linkEntity, value, taxonomyTerm, label) FROM Attribute WHERE linkId = ?1")
-    List<Attribute> getAttributes(String organizationId);
-
-    @Query("SELECT new Metadata(id, resourceId, resourceType, lastActionDate, lastActionType, fieldName, previousValue, replacementValue, updatedBy) FROM Metadata WHERE resourceId = ?1")
-    List<Metadata> getMetadata(String organizationId);
-
-    @Modifying
-    @Transactional
-    @Query("DELETE FROM Attribute WHERE linkId = ?1")
-    void deleteAttributes(String organizationId);
-
-    @Modifying
-    @Transactional
-    @Query("DELETE FROM Metadata WHERE resourceId = ?1")
-    void deleteMetadata(String organizationId);
 }

--- a/src/main/java/com/sarapis/orservice/repository/AttributeRepository.java
+++ b/src/main/java/com/sarapis/orservice/repository/AttributeRepository.java
@@ -1,7 +1,6 @@
 package com.sarapis.orservice.repository;
 
 import com.sarapis.orservice.entity.Attribute;
-import com.sarapis.orservice.entity.Metadata;
 import jakarta.transaction.Transactional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -12,11 +11,11 @@ import java.util.List;
 
 @Repository
 public interface AttributeRepository extends JpaRepository<Attribute, String> {
-    @Query("SELECT new Metadata(id, resourceId, resourceType, lastActionDate, lastActionType, fieldName, previousValue, replacementValue, updatedBy) FROM Metadata WHERE resourceId = ?1")
-    List<Metadata> getMetadata(String organizationId);
+    @Query("SELECT new Attribute(id, linkId, linkType, linkEntity, value, label, taxonomyTerm) FROM Attribute WHERE linkId = ?1")
+    List<Attribute> getRelatedAttributes(String linkId);
 
     @Modifying
     @Transactional
-    @Query("DELETE FROM Metadata WHERE resourceId = ?1")
-    void deleteMetadata(String organizationId);
+    @Query("DELETE FROM Attribute WHERE linkId = ?1")
+    void deleteRelatedAttributes(String linkId);
 }

--- a/src/main/java/com/sarapis/orservice/repository/ContactRepository.java
+++ b/src/main/java/com/sarapis/orservice/repository/ContactRepository.java
@@ -1,29 +1,7 @@
 package com.sarapis.orservice.repository;
 
-import com.sarapis.orservice.entity.Attribute;
 import com.sarapis.orservice.entity.Contact;
-import com.sarapis.orservice.entity.Metadata;
-import jakarta.transaction.Transactional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
-
-import java.util.List;
 
 public interface ContactRepository extends JpaRepository<Contact, String> {
-    @Query("SELECT new Attribute(id, linkId, linkType, linkEntity, value, taxonomyTerm, label) FROM Attribute WHERE linkId = ?1")
-    List<Attribute> getAttributes(String organizationId);
-
-    @Query("SELECT new Metadata(id, resourceId, resourceType, lastActionDate, lastActionType, fieldName, previousValue, replacementValue, updatedBy) FROM Metadata WHERE resourceId = ?1")
-    List<Metadata> getMetadata(String organizationId);
-
-    @Modifying
-    @Transactional
-    @Query("DELETE FROM Attribute WHERE linkId = ?1")
-    void deleteAttributes(String organizationId);
-
-    @Modifying
-    @Transactional
-    @Query("DELETE FROM Metadata WHERE resourceId = ?1")
-    void deleteMetadata(String organizationId);
 }

--- a/src/main/java/com/sarapis/orservice/repository/LanguageRepository.java
+++ b/src/main/java/com/sarapis/orservice/repository/LanguageRepository.java
@@ -1,31 +1,9 @@
 package com.sarapis.orservice.repository;
 
-import com.sarapis.orservice.entity.Attribute;
 import com.sarapis.orservice.entity.Language;
-import com.sarapis.orservice.entity.Metadata;
-import jakarta.transaction.Transactional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
-
-import java.util.List;
 
 @Repository
 public interface LanguageRepository extends JpaRepository<Language, String> {
-    @Query("SELECT new Attribute(id, linkId, linkType, linkEntity, value, taxonomyTerm, label) FROM Attribute WHERE linkId = ?1")
-    List<Attribute> getAttributes(String languageId);
-
-    @Query("SELECT new Metadata(id, resourceId, resourceType, lastActionDate, lastActionType, fieldName, previousValue, replacementValue, updatedBy) FROM Metadata WHERE resourceId = ?1")
-    List<Metadata> getMetadata(String languageId);
-
-    @Modifying
-    @Transactional
-    @Query("DELETE FROM Attribute WHERE linkId = ?1")
-    void deleteAttributes(String languageId);
-
-    @Modifying
-    @Transactional
-    @Query("DELETE FROM Metadata WHERE resourceId = ?1")
-    void deleteMetadata(String languageId);
 }

--- a/src/main/java/com/sarapis/orservice/repository/LocationRepository.java
+++ b/src/main/java/com/sarapis/orservice/repository/LocationRepository.java
@@ -1,0 +1,7 @@
+package com.sarapis.orservice.repository;
+
+import com.sarapis.orservice.entity.core.Location;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LocationRepository extends JpaRepository<Location, String> {
+}

--- a/src/main/java/com/sarapis/orservice/repository/MetadataRepository.java
+++ b/src/main/java/com/sarapis/orservice/repository/MetadataRepository.java
@@ -1,9 +1,21 @@
 package com.sarapis.orservice.repository;
 
 import com.sarapis.orservice.entity.Metadata;
+import jakarta.transaction.Transactional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface MetadataRepository extends JpaRepository<Metadata, String> {
+    @Query("SELECT new Metadata(id, resourceId, resourceType, lastActionDate, lastActionType, fieldName, previousValue, replacementValue, updatedBy) FROM Metadata WHERE resourceId = ?1")
+    List<Metadata> getRelatedMetadata(String resourceId);
+
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM Metadata WHERE resourceId = ?1")
+    void deleteRelatedMetadata(String resourceId);
 }

--- a/src/main/java/com/sarapis/orservice/repository/OrganizationRepository.java
+++ b/src/main/java/com/sarapis/orservice/repository/OrganizationRepository.java
@@ -1,31 +1,9 @@
 package com.sarapis.orservice.repository;
 
-import com.sarapis.orservice.entity.Attribute;
-import com.sarapis.orservice.entity.Metadata;
 import com.sarapis.orservice.entity.core.Organization;
-import jakarta.transaction.Transactional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
-
-import java.util.List;
 
 @Repository
 public interface OrganizationRepository extends JpaRepository<Organization, String> {
-    @Query("SELECT new Attribute(id, linkId, linkType, linkEntity, value, taxonomyTerm, label) FROM Attribute WHERE linkId = ?1")
-    List<Attribute> getAttributes(String organizationId);
-
-    @Query("SELECT new Metadata(id, resourceId, resourceType, lastActionDate, lastActionType, fieldName, previousValue, replacementValue, updatedBy) FROM Metadata WHERE resourceId = ?1")
-    List<Metadata> getMetadata(String organizationId);
-
-    @Modifying
-    @Transactional
-    @Query("DELETE FROM Attribute WHERE linkId = ?1")
-    void deleteAttributes(String organizationId);
-
-    @Modifying
-    @Transactional
-    @Query("DELETE FROM Metadata WHERE resourceId = ?1")
-    void deleteMetadata(String organizationId);
 }

--- a/src/main/java/com/sarapis/orservice/repository/PhoneRepository.java
+++ b/src/main/java/com/sarapis/orservice/repository/PhoneRepository.java
@@ -1,29 +1,7 @@
 package com.sarapis.orservice.repository;
 
-import com.sarapis.orservice.entity.Attribute;
 import com.sarapis.orservice.entity.Phone;
-import com.sarapis.orservice.entity.Metadata;
-import jakarta.transaction.Transactional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
-
-import java.util.List;
 
 public interface PhoneRepository extends JpaRepository<Phone, String> {
-    @Query("SELECT new Attribute(id, linkId, linkType, linkEntity, value, taxonomyTerm, label) FROM Attribute WHERE linkId = ?1")
-    List<Attribute> getAttributes(String organizationId);
-
-    @Query("SELECT new Metadata(id, resourceId, resourceType, lastActionDate, lastActionType, fieldName, previousValue, replacementValue, updatedBy) FROM Metadata WHERE resourceId = ?1")
-    List<Metadata> getMetadata(String organizationId);
-
-    @Modifying
-    @Transactional
-    @Query("DELETE FROM Attribute WHERE linkId = ?1")
-    void deleteAttributes(String organizationId);
-
-    @Modifying
-    @Transactional
-    @Query("DELETE FROM Metadata WHERE resourceId = ?1")
-    void deleteMetadata(String organizationId);
 }

--- a/src/main/java/com/sarapis/orservice/repository/ProgramRepository.java
+++ b/src/main/java/com/sarapis/orservice/repository/ProgramRepository.java
@@ -1,28 +1,7 @@
 package com.sarapis.orservice.repository;
 
-import com.sarapis.orservice.entity.Attribute;
-import com.sarapis.orservice.entity.Metadata;
 import com.sarapis.orservice.entity.Program;
-import jakarta.transaction.Transactional;
-import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
 
 public interface ProgramRepository extends JpaRepository<Program, String> {
-  @Query("SELECT new Attribute(id, linkId, linkType, linkEntity, value, taxonomyTerm, label) FROM Attribute WHERE linkId = ?1")
-  List<Attribute> getAttributes(String organizationId);
-
-  @Query("SELECT new Metadata(id, resourceId, resourceType, lastActionDate, lastActionType, fieldName, previousValue, replacementValue, updatedBy) FROM Metadata WHERE resourceId = ?1")
-  List<Metadata> getMetadata(String organizationId);
-
-  @Modifying
-  @Transactional
-  @Query("DELETE FROM Attribute WHERE linkId = ?1")
-  void deleteAttributes(String organizationId);
-
-  @Modifying
-  @Transactional
-  @Query("DELETE FROM Metadata WHERE resourceId =?1")
-  void deleteMetadata(String organizationId);
 }

--- a/src/main/java/com/sarapis/orservice/repository/ScheduleRepository.java
+++ b/src/main/java/com/sarapis/orservice/repository/ScheduleRepository.java
@@ -1,31 +1,9 @@
 package com.sarapis.orservice.repository;
 
-import com.sarapis.orservice.entity.Attribute;
-import com.sarapis.orservice.entity.Metadata;
 import com.sarapis.orservice.entity.Schedule;
-import jakarta.transaction.Transactional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
-
-import java.util.List;
 
 @Repository
 public interface ScheduleRepository extends JpaRepository<Schedule, String> {
-    @Query("SELECT new Attribute(id, linkId, linkType, linkEntity, value, taxonomyTerm, label) FROM Attribute WHERE linkId = ?1")
-    List<Attribute> getAttributes(String scheduleId);
-
-    @Query("SELECT new Metadata(id, resourceId, resourceType, lastActionDate, lastActionType, fieldName, previousValue, replacementValue, updatedBy) FROM Metadata WHERE resourceId = ?1")
-    List<Metadata> getMetadata(String scheduleId);
-
-    @Modifying
-    @Transactional
-    @Query("DELETE FROM Attribute WHERE linkId = ?1")
-    void deleteAttributes(String scheduleId);
-
-    @Modifying
-    @Transactional
-    @Query("DELETE FROM Metadata WHERE resourceId = ?1")
-    void deleteMetadata(String scheduleId);
 }

--- a/src/main/java/com/sarapis/orservice/repository/ServiceAreaRepository.java
+++ b/src/main/java/com/sarapis/orservice/repository/ServiceAreaRepository.java
@@ -1,31 +1,9 @@
 package com.sarapis.orservice.repository;
 
 import com.sarapis.orservice.entity.ServiceArea;
-import com.sarapis.orservice.entity.Attribute;
-import com.sarapis.orservice.entity.Metadata;
-import jakarta.transaction.Transactional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
-
-import java.util.List;
 
 @Repository
 public interface ServiceAreaRepository extends JpaRepository<ServiceArea, String> {
-    @Query("SELECT new Attribute(id, linkId, linkType, linkEntity, value, taxonomyTerm, label) FROM Attribute WHERE linkId = ?1")
-    List<Attribute> getAttributes(String organizationId);
-
-    @Query("SELECT new Metadata(id, resourceId, resourceType, lastActionDate, lastActionType, fieldName, previousValue, replacementValue, updatedBy) FROM Metadata WHERE resourceId = ?1")
-    List<Metadata> getMetadata(String organizationId);
-
-    @Modifying
-    @Transactional
-    @Query("DELETE FROM Attribute WHERE linkId = ?1")
-    void deleteAttributes(String organizationId);
-
-    @Modifying
-    @Transactional
-    @Query("DELETE FROM Metadata WHERE resourceId = ?1")
-    void deleteMetadata(String organizationId);
 }

--- a/src/main/java/com/sarapis/orservice/repository/ServiceAtLocationRepository.java
+++ b/src/main/java/com/sarapis/orservice/repository/ServiceAtLocationRepository.java
@@ -1,31 +1,9 @@
 package com.sarapis.orservice.repository;
 
-import com.sarapis.orservice.entity.Attribute;
-import com.sarapis.orservice.entity.Metadata;
 import com.sarapis.orservice.entity.core.ServiceAtLocation;
-import jakarta.transaction.Transactional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
-
-import java.util.List;
 
 @Repository
 public interface ServiceAtLocationRepository extends JpaRepository<ServiceAtLocation, String> {
-    @Query("SELECT new Attribute(id, linkId, linkType, linkEntity, value, taxonomyTerm, label) FROM Attribute WHERE linkId = ?1")
-    List<Attribute> getAttributes(String id);
-
-    @Query("SELECT new Metadata(id, resourceId, resourceType, lastActionDate, lastActionType, fieldName, previousValue, replacementValue, updatedBy) FROM Metadata WHERE resourceId = ?1")
-    List<Metadata> getMetadata(String id);
-
-    @Modifying
-    @Transactional
-    @Query("DELETE FROM Attribute WHERE linkId = ?1")
-    void deleteAttributes(String id);
-
-    @Modifying
-    @Transactional
-    @Query("DELETE FROM Metadata WHERE resourceId = ?1")
-    void deleteMetadata(String id);
 }

--- a/src/main/java/com/sarapis/orservice/service/AccessibilityService.java
+++ b/src/main/java/com/sarapis/orservice/service/AccessibilityService.java
@@ -7,11 +7,11 @@ import java.util.List;
 public interface AccessibilityService {
     List<AccessibilityDTO> getAllAccessibilities();
 
-    AccessibilityDTO getAccessibilityById(String id);
+    AccessibilityDTO getAccessibilityById(String accessibilityId);
 
     AccessibilityDTO createAccessibility(AccessibilityDTO accessibilityDTO);
 
-    AccessibilityDTO updateAccessibility(String id, AccessibilityDTO accessibilityDTO);
+    AccessibilityDTO updateAccessibility(String accessibilityId, AccessibilityDTO accessibilityDTO);
 
-    void deleteAccessibility(String id);
+    void deleteAccessibility(String accessibilityId);
 }

--- a/src/main/java/com/sarapis/orservice/service/AccessibilityServiceImpl.java
+++ b/src/main/java/com/sarapis/orservice/service/AccessibilityServiceImpl.java
@@ -1,14 +1,8 @@
 package com.sarapis.orservice.service;
 
 import com.sarapis.orservice.dto.AccessibilityDTO;
-import com.sarapis.orservice.dto.AttributeDTO;
-import com.sarapis.orservice.dto.MetadataDTO;
 import com.sarapis.orservice.entity.Accessibility;
-import com.sarapis.orservice.entity.Attribute;
-import com.sarapis.orservice.entity.Metadata;
 import com.sarapis.orservice.repository.AccessibilityRepository;
-import com.sarapis.orservice.repository.AttributeRepository;
-import com.sarapis.orservice.repository.MetadataRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -17,28 +11,29 @@ import java.util.List;
 @Service
 public class AccessibilityServiceImpl implements AccessibilityService {
     private final AccessibilityRepository accessibilityRepository;
-    private final AttributeRepository attributeRepository;
-    private final MetadataRepository metadataRepository;
+    private final AttributeService attributeService;
+    private final MetadataService metadataService;
 
     @Autowired
-    public AccessibilityServiceImpl(AccessibilityRepository accessibilityRepository, AttributeRepository attributeRepository, MetadataRepository metadataRepository) {
+    public AccessibilityServiceImpl(AccessibilityRepository accessibilityRepository,
+                                    AttributeService attributeService,
+                                    MetadataService metadataService) {
         this.accessibilityRepository = accessibilityRepository;
-        this.attributeRepository = attributeRepository;
-        this.metadataRepository = metadataRepository;
+        this.attributeService = attributeService;
+        this.metadataService = metadataService;
     }
 
     @Override
     public List<AccessibilityDTO> getAllAccessibilities() {
-        List<AccessibilityDTO> accessibilityDTOs = this.accessibilityRepository.findAll().stream().map(Accessibility::toDTO).toList();
+        List<AccessibilityDTO> accessibilityDTOs = this.accessibilityRepository.findAll()
+                .stream().map(Accessibility::toDTO).toList();
         accessibilityDTOs.forEach(this::addRelatedData);
         return accessibilityDTOs;
     }
 
-
-
     @Override
-    public AccessibilityDTO getAccessibilityById(String id) {
-        Accessibility accessibility = this.accessibilityRepository.findById(id)
+    public AccessibilityDTO getAccessibilityById(String accessibilityId) {
+        Accessibility accessibility = this.accessibilityRepository.findById(accessibilityId)
                 .orElseThrow(() -> new RuntimeException("Accessibility not found."));
         AccessibilityDTO accessibilityDTO = accessibility.toDTO();
         this.addRelatedData(accessibilityDTO);
@@ -47,45 +42,40 @@ public class AccessibilityServiceImpl implements AccessibilityService {
 
     @Override
     public AccessibilityDTO createAccessibility(AccessibilityDTO accessibilityDTO) {
-        Accessibility accessibility = this.accessibilityRepository.save(accessibilityDTO.toEntity());
+        Accessibility accessibility = this.accessibilityRepository.save(accessibilityDTO.toEntity(null));
+        accessibilityDTO.getAttributes()
+                .forEach(attributeDTO -> this.attributeService.createAttribute(accessibility.getId(), attributeDTO));
+        accessibilityDTO.getMetadata()
+                .forEach(e -> this.metadataService.createMetadata(accessibility.getId(), e));
 
-        for (AttributeDTO attributeDTO : accessibilityDTO.getAttributes()) {
-            this.attributeRepository.save(attributeDTO.toEntity(accessibility.getId()));
-        }
-
-        for (MetadataDTO metadataDTO : accessibilityDTO.getMetadata()) {
-            this.metadataRepository.save(metadataDTO.toEntity(accessibility.getId()));
-        }
-
-        AccessibilityDTO savedAccessibilityDTO = this.accessibilityRepository.save(accessibility).toDTO();
-        this.addRelatedData(savedAccessibilityDTO);
-        return savedAccessibilityDTO;
+        Accessibility createdAccessibility = this.accessibilityRepository.save(accessibility);
+        return this.getAccessibilityById(createdAccessibility.getId());
     }
 
     @Override
-    public AccessibilityDTO updateAccessibility(String id, AccessibilityDTO accessibilityDTO) {
-        Accessibility oldAccessibility = this.accessibilityRepository.findById(id)
+    public AccessibilityDTO updateAccessibility(String accessibilityId, AccessibilityDTO accessibilityDTO) {
+        Accessibility accessibility = this.accessibilityRepository.findById(accessibilityId)
                 .orElseThrow(() -> new RuntimeException("Accessibility not found."));
 
-        oldAccessibility.setDescription(accessibilityDTO.getDescription());
-        oldAccessibility.setDetails(accessibilityDTO.getDetails());
-        oldAccessibility.setUrl(accessibilityDTO.getUrl());
+        accessibility.setDescription(accessibilityDTO.getDescription());
+        accessibility.setDetails(accessibilityDTO.getDetails());
+        accessibility.setUrl(accessibilityDTO.getUrl());
 
-        Accessibility updatedAccessibility = this.accessibilityRepository.save(oldAccessibility);
-        return updatedAccessibility.toDTO();
+        Accessibility updatedAccessibility = this.accessibilityRepository.save(accessibility);
+        return this.getAccessibilityById(updatedAccessibility.getId());
     }
 
     @Override
-    public void deleteAccessibility(String id) {
-        Accessibility accessibility = this.accessibilityRepository.findById(id)
+    public void deleteAccessibility(String accessibilityId) {
+        Accessibility accessibility = this.accessibilityRepository.findById(accessibilityId)
                 .orElseThrow(() -> new RuntimeException("Accessibility not found."));
-        this.accessibilityRepository.deleteAttributes(accessibility.getId());
-        this.accessibilityRepository.deleteMetadata(accessibility.getId());
+        this.attributeService.deleteRelatedAttributes(accessibility.getId());
+        this.metadataService.deleteRelatedMetadata(accessibility.getId());
         this.accessibilityRepository.delete(accessibility);
     }
 
     private void addRelatedData(AccessibilityDTO accessibilityDTO) {
-        accessibilityDTO.getAttributes().addAll(this.accessibilityRepository.getAttributes(accessibilityDTO.getId()).stream().map(Attribute::toDTO).toList());
-        accessibilityDTO.getMetadata().addAll(this.accessibilityRepository.getMetadata(accessibilityDTO.getId()).stream().map(Metadata::toDTO).toList());
+        accessibilityDTO.getAttributes().addAll(this.attributeService.getRelatedAttributes(accessibilityDTO.getId()));
+        accessibilityDTO.getMetadata().addAll(this.metadataService.getRelatedMetadata(accessibilityDTO.getId()));
     }
 }

--- a/src/main/java/com/sarapis/orservice/service/AccessibilityServiceImpl.java
+++ b/src/main/java/com/sarapis/orservice/service/AccessibilityServiceImpl.java
@@ -2,7 +2,9 @@ package com.sarapis.orservice.service;
 
 import com.sarapis.orservice.dto.AccessibilityDTO;
 import com.sarapis.orservice.entity.Accessibility;
+import com.sarapis.orservice.entity.core.Location;
 import com.sarapis.orservice.repository.AccessibilityRepository;
+import com.sarapis.orservice.repository.LocationRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -11,14 +13,17 @@ import java.util.List;
 @Service
 public class AccessibilityServiceImpl implements AccessibilityService {
     private final AccessibilityRepository accessibilityRepository;
+    private final LocationRepository locationRepository;
     private final AttributeService attributeService;
     private final MetadataService metadataService;
 
     @Autowired
     public AccessibilityServiceImpl(AccessibilityRepository accessibilityRepository,
+                                    LocationRepository locationRepository,
                                     AttributeService attributeService,
                                     MetadataService metadataService) {
         this.accessibilityRepository = accessibilityRepository;
+        this.locationRepository = locationRepository;
         this.attributeService = attributeService;
         this.metadataService = metadataService;
     }
@@ -42,7 +47,14 @@ public class AccessibilityServiceImpl implements AccessibilityService {
 
     @Override
     public AccessibilityDTO createAccessibility(AccessibilityDTO accessibilityDTO) {
-        Accessibility accessibility = this.accessibilityRepository.save(accessibilityDTO.toEntity(null));
+        Location location = null;
+
+        if (accessibilityDTO.getLocationId() != null) {
+            location = this.locationRepository.findById(accessibilityDTO.getLocationId())
+                    .orElseThrow(() -> new RuntimeException("Location not found."));
+        }
+
+        Accessibility accessibility = this.accessibilityRepository.save(accessibilityDTO.toEntity(location));
         accessibilityDTO.getAttributes()
                 .forEach(attributeDTO -> this.attributeService.createAttribute(accessibility.getId(), attributeDTO));
         accessibilityDTO.getMetadata()

--- a/src/main/java/com/sarapis/orservice/service/AddressService.java
+++ b/src/main/java/com/sarapis/orservice/service/AddressService.java
@@ -7,11 +7,11 @@ import java.util.List;
 public interface AddressService {
     List<AddressDTO> getAllAddresses();
 
-    AddressDTO getAddressById(String id);
+    AddressDTO getAddressById(String addressId);
 
     AddressDTO createAddress(AddressDTO addressDTO);
 
-    AddressDTO updateAddress(String id, AddressDTO addressDTO);
+    AddressDTO updateAddress(String addressId, AddressDTO addressDTO);
 
-    void deleteAddress(String id);
+    void deleteAddress(String addressId);
 }

--- a/src/main/java/com/sarapis/orservice/service/AddressServiceImpl.java
+++ b/src/main/java/com/sarapis/orservice/service/AddressServiceImpl.java
@@ -1,14 +1,8 @@
 package com.sarapis.orservice.service;
 
 import com.sarapis.orservice.dto.AddressDTO;
-import com.sarapis.orservice.dto.AttributeDTO;
-import com.sarapis.orservice.dto.MetadataDTO;
 import com.sarapis.orservice.entity.Address;
-import com.sarapis.orservice.entity.Attribute;
-import com.sarapis.orservice.entity.Metadata;
 import com.sarapis.orservice.repository.AddressRepository;
-import com.sarapis.orservice.repository.AttributeRepository;
-import com.sarapis.orservice.repository.MetadataRepository;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -16,25 +10,28 @@ import java.util.List;
 @Service
 public class AddressServiceImpl implements AddressService {
     private final AddressRepository addressRepository;
-    private final AttributeRepository attributeRepository;
-    private final MetadataRepository metadataRepository;
+    private final AttributeService attributeService;
+    private final MetadataService metadataService;
 
-    public AddressServiceImpl(AddressRepository addressRepository, AttributeRepository attributeRepository, MetadataRepository metadataRepository) {
+    public AddressServiceImpl(AddressRepository addressRepository,
+                              AttributeService attributeService,
+                              MetadataService metadataService) {
         this.addressRepository = addressRepository;
-        this.attributeRepository = attributeRepository;
-        this.metadataRepository = metadataRepository;
+        this.attributeService = attributeService;
+        this.metadataService = metadataService;
     }
 
     @Override
     public List<AddressDTO> getAllAddresses() {
-        List<AddressDTO> addressDTOs = this.addressRepository.findAll().stream().map(Address::toDTO).toList();
+        List<AddressDTO> addressDTOs = this.addressRepository.findAll()
+                .stream().map(Address::toDTO).toList();
         addressDTOs.forEach(this::addRelatedData);
         return addressDTOs;
     }
 
     @Override
-    public AddressDTO getAddressById(String id) {
-        Address address = this.addressRepository.findById(id)
+    public AddressDTO getAddressById(String addressId) {
+        Address address = this.addressRepository.findById(addressId)
                 .orElseThrow(() -> new RuntimeException("Address not found."));
         AddressDTO addressDTO = address.toDTO();
         this.addRelatedData(addressDTO);
@@ -43,52 +40,46 @@ public class AddressServiceImpl implements AddressService {
 
     @Override
     public AddressDTO createAddress(AddressDTO addressDTO) {
-        Address address = this.addressRepository.save(addressDTO.toEntity());
+        Address address = this.addressRepository.save(addressDTO.toEntity(null));
+        addressDTO.getAttributes()
+                .forEach(attributeDTO -> this.attributeService.createAttribute(address.getId(), attributeDTO));
+        addressDTO.getMetadata()
+                .forEach(e -> this.metadataService.createMetadata(address.getId(), e));
 
-        for (AttributeDTO attributeDTO : addressDTO.getAttributes()) {
-            this.attributeRepository.save(attributeDTO.toEntity(address.getId()));
-        }
-
-        for (MetadataDTO metadataDTO : addressDTO.getMetadata()) {
-            this.metadataRepository.save(metadataDTO.toEntity(address.getId()));
-        }
-
-        AddressDTO savedAddressDTO = this.addressRepository.save(address).toDTO();
-        this.addRelatedData(savedAddressDTO);
-        return savedAddressDTO;
+        Address createdAddress = this.addressRepository.save(address);
+        return this.getAddressById(createdAddress.getId());
     }
 
     @Override
-    public AddressDTO updateAddress(String id, AddressDTO addressDTO) {
-        Address oldAddress = this.addressRepository.findById(id)
+    public AddressDTO updateAddress(String addressId, AddressDTO addressDTO) {
+        Address address = this.addressRepository.findById(addressId)
                 .orElseThrow(() -> new RuntimeException("Address not found."));
 
-        oldAddress.setAttention(addressDTO.getAttention());
-        oldAddress.setAddress_1(addressDTO.getAddress_1());
-        oldAddress.setAddress_2(addressDTO.getAddress_2());
-        oldAddress.setCity(addressDTO.getCity());
-        oldAddress.setRegion(addressDTO.getRegion());
-        oldAddress.setStateProvince(addressDTO.getStateProvince());
-        oldAddress.setPostalCode(addressDTO.getPostalCode());
-        oldAddress.setCountry(addressDTO.getCountry());
-        oldAddress.setAddressType(addressDTO.getAddressType());
+        address.setAttention(addressDTO.getAttention());
+        address.setAddress_1(addressDTO.getAddress_1());
+        address.setAddress_2(addressDTO.getAddress_2());
+        address.setCity(addressDTO.getCity());
+        address.setRegion(addressDTO.getRegion());
+        address.setStateProvince(addressDTO.getStateProvince());
+        address.setPostalCode(addressDTO.getPostalCode());
+        address.setCountry(addressDTO.getCountry());
+        address.setAddressType(addressDTO.getAddressType());
 
-        Address updatedAddress = this.addressRepository.save(oldAddress);
-        return updatedAddress.toDTO();
+        Address updatedAddress = this.addressRepository.save(address);
+        return this.getAddressById(updatedAddress.getId());
     }
 
     @Override
-    public void deleteAddress(String id) {
-        Address address = this.addressRepository.findById(id)
+    public void deleteAddress(String addressId) {
+        Address address = this.addressRepository.findById(addressId)
                 .orElseThrow(() -> new RuntimeException("Address not found."));
-
-        this.addressRepository.deleteAttributes(address.getId());
-        this.addressRepository.deleteMetadata(address.getId());
+        this.attributeService.deleteRelatedAttributes(address.getId());
+        this.metadataService.deleteRelatedMetadata(address.getId());
         this.addressRepository.delete(address);
     }
 
     private void addRelatedData(AddressDTO addressDTO) {
-        addressDTO.getAttributes().addAll(this.addressRepository.getAttributes(addressDTO.getId()).stream().map(Attribute::toDTO).toList());
-        addressDTO.getMetadata().addAll(this.addressRepository.getMetadata(addressDTO.getId()).stream().map(Metadata::toDTO).toList());
+        addressDTO.getAttributes().addAll(this.attributeService.getRelatedAttributes(addressDTO.getId()));
+        addressDTO.getMetadata().addAll(this.metadataService.getRelatedMetadata(addressDTO.getId()));
     }
 }

--- a/src/main/java/com/sarapis/orservice/service/AddressServiceImpl.java
+++ b/src/main/java/com/sarapis/orservice/service/AddressServiceImpl.java
@@ -2,7 +2,9 @@ package com.sarapis.orservice.service;
 
 import com.sarapis.orservice.dto.AddressDTO;
 import com.sarapis.orservice.entity.Address;
+import com.sarapis.orservice.entity.core.Location;
 import com.sarapis.orservice.repository.AddressRepository;
+import com.sarapis.orservice.repository.LocationRepository;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -10,13 +12,16 @@ import java.util.List;
 @Service
 public class AddressServiceImpl implements AddressService {
     private final AddressRepository addressRepository;
+    private final LocationRepository locationRepository;
     private final AttributeService attributeService;
     private final MetadataService metadataService;
 
     public AddressServiceImpl(AddressRepository addressRepository,
+                              LocationRepository locationRepository,
                               AttributeService attributeService,
                               MetadataService metadataService) {
         this.addressRepository = addressRepository;
+        this.locationRepository = locationRepository;
         this.attributeService = attributeService;
         this.metadataService = metadataService;
     }
@@ -40,7 +45,14 @@ public class AddressServiceImpl implements AddressService {
 
     @Override
     public AddressDTO createAddress(AddressDTO addressDTO) {
-        Address address = this.addressRepository.save(addressDTO.toEntity(null));
+        Location location = null;
+
+        if (addressDTO.getLocationId() != null) {
+            location = this.locationRepository.findById(addressDTO.getLocationId())
+                    .orElseThrow(() -> new RuntimeException("Location not found."));
+        }
+
+        Address address = this.addressRepository.save(addressDTO.toEntity(location));
         addressDTO.getAttributes()
                 .forEach(attributeDTO -> this.attributeService.createAttribute(address.getId(), attributeDTO));
         addressDTO.getMetadata()

--- a/src/main/java/com/sarapis/orservice/service/AttributeService.java
+++ b/src/main/java/com/sarapis/orservice/service/AttributeService.java
@@ -7,11 +7,15 @@ import java.util.List;
 public interface AttributeService {
     List<AttributeDTO> getAllAttributes();
 
-    AttributeDTO getAttributeById(String id);
+    List<AttributeDTO> getRelatedAttributes(String linkId);
 
-    AttributeDTO createAttribute(AttributeDTO attributeDTO);
+    AttributeDTO getAttributeById(String attributeId);
 
-    AttributeDTO updateAttribute(String id, AttributeDTO attributeDTO);
+    AttributeDTO createAttribute(String linkId, AttributeDTO attributeDTO);
 
-    void deleteAttribute(String id);
+    AttributeDTO updateAttribute(String attributeId, AttributeDTO attributeDTO);
+
+    void deleteAttribute(String attributeId);
+
+    void deleteRelatedAttributes(String linkId);
 }

--- a/src/main/java/com/sarapis/orservice/service/AttributeServiceImpl.java
+++ b/src/main/java/com/sarapis/orservice/service/AttributeServiceImpl.java
@@ -58,11 +58,11 @@ public class AttributeServiceImpl implements AttributeService {
                 .orElseThrow(() -> new RuntimeException("Attribute not found."));
 
         attribute.setLinkId(attributeDTO.getLinkId());
-        attribute.setTaxonomyTerm(attributeDTO.getTaxonomyTerm().toEntity(null));
         attribute.setLinkType(attributeDTO.getLinkType());
         attribute.setLinkEntity(attributeDTO.getLinkEntity());
         attribute.setValue(attributeDTO.getValue());
         attribute.setLabel(attributeDTO.getLabel());
+        attribute.setTaxonomyTerm(attributeDTO.getTaxonomyTerm().toEntity(null));
 
         Attribute updatedAttribute = this.attributeRepository.save(attribute);
         return this.getAttributeById(updatedAttribute.getId());

--- a/src/main/java/com/sarapis/orservice/service/AttributeServiceImpl.java
+++ b/src/main/java/com/sarapis/orservice/service/AttributeServiceImpl.java
@@ -1,11 +1,8 @@
 package com.sarapis.orservice.service;
 
 import com.sarapis.orservice.dto.AttributeDTO;
-import com.sarapis.orservice.dto.MetadataDTO;
 import com.sarapis.orservice.entity.Attribute;
-import com.sarapis.orservice.entity.Metadata;
 import com.sarapis.orservice.repository.AttributeRepository;
-import com.sarapis.orservice.repository.MetadataRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -14,24 +11,32 @@ import java.util.List;
 @Service
 public class AttributeServiceImpl implements AttributeService {
     private final AttributeRepository attributeRepository;
-    private final MetadataRepository metadataRepository;
+    private final MetadataService metadataService;
 
     @Autowired
-    public AttributeServiceImpl(AttributeRepository attributeRepository, MetadataRepository metadataRepository) {
+    public AttributeServiceImpl(AttributeRepository attributeRepository,
+                                MetadataService metadataService) {
         this.attributeRepository = attributeRepository;
-        this.metadataRepository = metadataRepository;
+        this.metadataService = metadataService;
     }
 
     @Override
     public List<AttributeDTO> getAllAttributes() {
-        List<AttributeDTO> attributeDTOs = this.attributeRepository.findAll().stream().map(Attribute::toDTO).toList();
+        List<AttributeDTO> attributeDTOs = this.attributeRepository.findAll()
+                .stream().map(Attribute::toDTO).toList();
         attributeDTOs.forEach(this::addRelatedData);
         return attributeDTOs;
     }
 
     @Override
-    public AttributeDTO getAttributeById(String id) {
-        Attribute attribute = this.attributeRepository.findById(id)
+    public List<AttributeDTO> getRelatedAttributes(String linkId) {
+        return this.attributeRepository.getRelatedAttributes(linkId)
+                .stream().map(Attribute::toDTO).toList();
+    }
+
+    @Override
+    public AttributeDTO getAttributeById(String attributeId) {
+        Attribute attribute = this.attributeRepository.findById(attributeId)
                 .orElseThrow(() -> new RuntimeException("Attribute not found."));
         AttributeDTO attributeDTO = attribute.toDTO();
         this.addRelatedData(attributeDTO);
@@ -39,43 +44,44 @@ public class AttributeServiceImpl implements AttributeService {
     }
 
     @Override
-    public AttributeDTO createAttribute(AttributeDTO attributeDTO) {
-        Attribute attribute = this.attributeRepository.save(attributeDTO.toEntity(attributeDTO.getLinkId()));
+    public AttributeDTO createAttribute(String linkId, AttributeDTO attributeDTO) {
+        Attribute attribute = this.attributeRepository.save(attributeDTO.toEntity(linkId));
+        attributeDTO.getMetadata().forEach(e -> this.metadataService.createMetadata(attribute.getId(), e));
 
-        for (MetadataDTO metadataDTO : attributeDTO.getMetadata()) {
-            this.metadataRepository.save(metadataDTO.toEntity(attribute.getId()));
-        }
-
-        AttributeDTO savedAttributedDTO = this.attributeRepository.save(attribute).toDTO();
-        this.addRelatedData(savedAttributedDTO);
-        return savedAttributedDTO;
+        Attribute createdAttribute = this.attributeRepository.save(attribute);
+        return this.getAttributeById(createdAttribute.getId());
     }
 
     @Override
-    public AttributeDTO updateAttribute(String id, AttributeDTO attributeDTO) {
-        Attribute oldAttribute = this.attributeRepository.findById(id)
+    public AttributeDTO updateAttribute(String attributeId, AttributeDTO attributeDTO) {
+        Attribute attribute = this.attributeRepository.findById(attributeId)
                 .orElseThrow(() -> new RuntimeException("Attribute not found."));
 
-        oldAttribute.setLinkId(attributeDTO.getLinkId());
-        oldAttribute.setLinkType(attributeDTO.getLinkType());
-        oldAttribute.setLinkEntity(attributeDTO.getLinkEntity());
-        oldAttribute.setValue(attributeDTO.getValue());
-        oldAttribute.setTaxonomyTerm(attributeDTO.getTaxonomyTerm().toEntity());
-        oldAttribute.setLabel(attributeDTO.getLabel());
+        attribute.setLinkId(attributeDTO.getLinkId());
+        attribute.setTaxonomyTerm(attributeDTO.getTaxonomyTerm().toEntity(null));
+        attribute.setLinkType(attributeDTO.getLinkType());
+        attribute.setLinkEntity(attributeDTO.getLinkEntity());
+        attribute.setValue(attributeDTO.getValue());
+        attribute.setLabel(attributeDTO.getLabel());
 
-        Attribute updatedAttribute = this.attributeRepository.save(oldAttribute);
-        return updatedAttribute.toDTO();
+        Attribute updatedAttribute = this.attributeRepository.save(attribute);
+        return this.getAttributeById(updatedAttribute.getId());
     }
 
     @Override
-    public void deleteAttribute(String id) {
-        Attribute attribute = this.attributeRepository.findById(id)
+    public void deleteAttribute(String attributeId) {
+        Attribute attribute = this.attributeRepository.findById(attributeId)
                 .orElseThrow(() -> new RuntimeException("Attribute not found."));
-        this.attributeRepository.deleteMetadata(attribute.getId());
+        this.metadataService.deleteRelatedMetadata(attribute.getId());
         this.attributeRepository.delete(attribute);
     }
 
+    @Override
+    public void deleteRelatedAttributes(String linkId) {
+        this.attributeRepository.deleteRelatedAttributes(linkId);
+    }
+
     private void addRelatedData(AttributeDTO attributeDTO) {
-        attributeDTO.getMetadata().addAll(this.attributeRepository.getMetadata(attributeDTO.getId()).stream().map(Metadata::toDTO).toList());
+        attributeDTO.getMetadata().addAll(this.metadataService.getRelatedMetadata(attributeDTO.getId()));
     }
 }

--- a/src/main/java/com/sarapis/orservice/service/ContactService.java
+++ b/src/main/java/com/sarapis/orservice/service/ContactService.java
@@ -7,11 +7,11 @@ import java.util.List;
 public interface ContactService {
     List<ContactDTO> getAllContacts();
 
-    ContactDTO getContactById(String id);
+    ContactDTO getContactById(String contactId);
 
     ContactDTO createContact(ContactDTO contactDTO);
 
-    ContactDTO updateContact(String id, ContactDTO contactDTO);
+    ContactDTO updateContact(String contactId, ContactDTO contactDTO);
 
-    void deleteContact(String id);
+    void deleteContact(String contactId);
 }

--- a/src/main/java/com/sarapis/orservice/service/ContactServiceImpl.java
+++ b/src/main/java/com/sarapis/orservice/service/ContactServiceImpl.java
@@ -1,14 +1,8 @@
 package com.sarapis.orservice.service;
 
-import com.sarapis.orservice.dto.AttributeDTO;
 import com.sarapis.orservice.dto.ContactDTO;
-import com.sarapis.orservice.dto.MetadataDTO;
-import com.sarapis.orservice.entity.Attribute;
 import com.sarapis.orservice.entity.Contact;
-import com.sarapis.orservice.entity.Metadata;
-import com.sarapis.orservice.repository.AttributeRepository;
 import com.sarapis.orservice.repository.ContactRepository;
-import com.sarapis.orservice.repository.MetadataRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -17,14 +11,16 @@ import java.util.List;
 @Service
 public class ContactServiceImpl implements ContactService {
     private final ContactRepository contactRepository;
-    private final AttributeRepository attributeRepository;
-    private final MetadataRepository metadataRepository;
+    private final AttributeService attributeService;
+    private final MetadataService metadataService;
 
     @Autowired
-    public ContactServiceImpl(ContactRepository contactRepository, AttributeRepository attributeRepository, MetadataRepository metadataRepository) {
+    public ContactServiceImpl(ContactRepository contactRepository,
+                              AttributeService attributeService,
+                              MetadataService metadataService) {
         this.contactRepository = contactRepository;
-        this.attributeRepository = attributeRepository;
-        this.metadataRepository = metadataRepository;
+        this.attributeService = attributeService;
+        this.metadataService = metadataService;
     }
 
     @Override
@@ -35,8 +31,8 @@ public class ContactServiceImpl implements ContactService {
     }
 
     @Override
-    public ContactDTO getContactById(String id) {
-        Contact contact = this.contactRepository.findById(id)
+    public ContactDTO getContactById(String contactId) {
+        Contact contact = this.contactRepository.findById(contactId)
                 .orElseThrow(() -> new RuntimeException("Contact not found."));
         ContactDTO contactDTO = contact.toDTO();
         this.addRelatedData(contactDTO);
@@ -45,46 +41,40 @@ public class ContactServiceImpl implements ContactService {
 
     @Override
     public ContactDTO createContact(ContactDTO contactDTO) {
-        Contact contact = this.contactRepository.save(contactDTO.toEntity());
+        Contact contact = this.contactRepository.save(contactDTO.toEntity(null, null, null, null));
+        contactDTO.getAttributes()
+                .forEach(attributeDTO -> this.attributeService.createAttribute(contact.getId(), attributeDTO));
+        contactDTO.getMetadata().forEach(e -> this.metadataService.createMetadata(contact.getId(), e));
 
-        for (AttributeDTO attributeDTO : contactDTO.getAttributes()) {
-            this.attributeRepository.save(attributeDTO.toEntity(contact.getId()));
-        }
-
-        for (MetadataDTO metadataDTO : contactDTO.getMetadata()) {
-            this.metadataRepository.save(metadataDTO.toEntity(contact.getId()));
-        }
-
-        ContactDTO savedContactDTO = this.contactRepository.save(contact).toDTO();
-        this.addRelatedData(savedContactDTO);
-        return savedContactDTO;
+        Contact createdContact = this.contactRepository.save(contact);
+        return this.getContactById(createdContact.getId());
     }
 
     @Override
-    public ContactDTO updateContact(String id, ContactDTO contactDTO) {
-        Contact oldContact = this.contactRepository.findById(id)
+    public ContactDTO updateContact(String contactId, ContactDTO contactDTO) {
+        Contact contact = this.contactRepository.findById(contactId)
                 .orElseThrow(() -> new RuntimeException("Contact not found."));
 
-        oldContact.setName(contactDTO.getName());
-        oldContact.setTitle(contactDTO.getTitle());
-        oldContact.setDepartment(contactDTO.getDepartment());
-        oldContact.setEmail(contactDTO.getEmail());
+        contact.setName(contactDTO.getName());
+        contact.setTitle(contactDTO.getTitle());
+        contact.setDepartment(contactDTO.getDepartment());
+        contact.setEmail(contactDTO.getEmail());
 
-        Contact updatedContactDTO = this.contactRepository.save(oldContact);
-        return updatedContactDTO.toDTO();
+        Contact updatedContact = this.contactRepository.save(contact);
+        return this.getContactById(updatedContact.getId());
     }
 
     @Override
-    public void deleteContact(String id) {
-        Contact contact = this.contactRepository.findById(id)
+    public void deleteContact(String contactId) {
+        Contact contact = this.contactRepository.findById(contactId)
                 .orElseThrow(() -> new RuntimeException("Contact not found."));
-        this.contactRepository.deleteAttributes(contact.getId());
-        this.contactRepository.deleteMetadata(contact.getId());
+        this.attributeService.deleteRelatedAttributes(contact.getId());
+        this.metadataService.deleteRelatedMetadata(contact.getId());
         this.contactRepository.delete(contact);
     }
 
     private void addRelatedData(ContactDTO contactDTO) {
-        contactDTO.getAttributes().addAll(this.contactRepository.getAttributes(contactDTO.getId()).stream().map(Attribute::toDTO).toList());
-        contactDTO.getMetadata().addAll(this.contactRepository.getMetadata(contactDTO.getId()).stream().map(Metadata::toDTO).toList());
+        contactDTO.getAttributes().addAll(this.attributeService.getRelatedAttributes(contactDTO.getId()));
+        contactDTO.getMetadata().addAll(this.metadataService.getRelatedMetadata(contactDTO.getId()));
     }
 }

--- a/src/main/java/com/sarapis/orservice/service/ContactServiceImpl.java
+++ b/src/main/java/com/sarapis/orservice/service/ContactServiceImpl.java
@@ -2,7 +2,10 @@ package com.sarapis.orservice.service;
 
 import com.sarapis.orservice.dto.ContactDTO;
 import com.sarapis.orservice.entity.Contact;
-import com.sarapis.orservice.repository.ContactRepository;
+import com.sarapis.orservice.entity.core.Location;
+import com.sarapis.orservice.entity.core.Organization;
+import com.sarapis.orservice.entity.core.ServiceAtLocation;
+import com.sarapis.orservice.repository.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -11,14 +14,26 @@ import java.util.List;
 @Service
 public class ContactServiceImpl implements ContactService {
     private final ContactRepository contactRepository;
+    private final OrganizationRepository organizationRepository;
+    private final ServiceRepository serviceRepository;
+    private final ServiceAtLocationRepository serviceAtLocationRepository;
+    private final LocationRepository locationRepository;
     private final AttributeService attributeService;
     private final MetadataService metadataService;
 
     @Autowired
     public ContactServiceImpl(ContactRepository contactRepository,
+                              OrganizationRepository organizationRepository,
+                              ServiceRepository serviceRepository,
+                              ServiceAtLocationRepository serviceAtLocationRepository,
+                              LocationRepository locationRepository,
                               AttributeService attributeService,
                               MetadataService metadataService) {
         this.contactRepository = contactRepository;
+        this.organizationRepository = organizationRepository;
+        this.serviceRepository = serviceRepository;
+        this.serviceAtLocationRepository = serviceAtLocationRepository;
+        this.locationRepository = locationRepository;
         this.attributeService = attributeService;
         this.metadataService = metadataService;
     }
@@ -41,7 +56,29 @@ public class ContactServiceImpl implements ContactService {
 
     @Override
     public ContactDTO createContact(ContactDTO contactDTO) {
-        Contact contact = this.contactRepository.save(contactDTO.toEntity(null, null, null, null));
+        Organization organization = null;
+        com.sarapis.orservice.entity.core.Service service = null;
+        ServiceAtLocation serviceAtLocation = null;
+        Location location = null;
+
+        if (contactDTO.getOrganizationId() != null) {
+            organization = this.organizationRepository.findById(contactDTO.getOrganizationId())
+                    .orElseThrow(() -> new RuntimeException("Organization not found."));
+        }
+        if (contactDTO.getServiceId() != null) {
+            service = this.serviceRepository.findById(contactDTO.getServiceId())
+                    .orElseThrow(() -> new RuntimeException("Service not found."));
+        }
+        if (contactDTO.getServiceAtLocationId() != null) {
+            serviceAtLocation = this.serviceAtLocationRepository.findById(contactDTO.getServiceAtLocationId())
+                    .orElseThrow(() -> new RuntimeException("Service at location not found."));
+        }
+        if (contactDTO.getLocationId() != null) {
+            location = this.locationRepository.findById(contactDTO.getLocationId())
+                    .orElseThrow(() -> new RuntimeException("Location not found."));
+        }
+
+        Contact contact = this.contactRepository.save(contactDTO.toEntity(organization, service, serviceAtLocation, location));
         contactDTO.getAttributes()
                 .forEach(attributeDTO -> this.attributeService.createAttribute(contact.getId(), attributeDTO));
         contactDTO.getMetadata().forEach(e -> this.metadataService.createMetadata(contact.getId(), e));

--- a/src/main/java/com/sarapis/orservice/service/ExportService.java
+++ b/src/main/java/com/sarapis/orservice/service/ExportService.java
@@ -5,7 +5,7 @@ import java.util.Map;
 import org.springframework.core.io.InputStreamResource;
 
 public interface ExportService {
-  InputStreamResource createCsvZip() throws IOException;
+    InputStreamResource createCsvZip() throws IOException;
 
-  InputStreamResource createPdfZip() throws IOException;
+    InputStreamResource createPdfZip() throws IOException;
 }

--- a/src/main/java/com/sarapis/orservice/service/ExportServiceImpl.java
+++ b/src/main/java/com/sarapis/orservice/service/ExportServiceImpl.java
@@ -10,42 +10,40 @@ import java.util.zip.ZipOutputStream;
 import org.springframework.core.io.InputStreamResource;
 
 public class ExportServiceImpl implements ExportService {
-  private static void addToZip(
-      ZipOutputStream zipOut,
-      String fileName,
-      InputStreamResource resource) throws IOException {
+    private static void addToZip(ZipOutputStream zipOut, String fileName, InputStreamResource resource)
+            throws IOException {
 
-    ZipEntry zipEntry = new ZipEntry(fileName);
-    zipOut.putNextEntry(zipEntry);
+        ZipEntry zipEntry = new ZipEntry(fileName);
+        zipOut.putNextEntry(zipEntry);
 
-    try (InputStream inputStream = resource.getInputStream()) {
-      byte[] bytes = new byte[1024];
-      int length;
-      while ((length = inputStream.read(bytes)) >= 0) {
-        zipOut.write(bytes, 0, length);
-      }
+        try (InputStream inputStream = resource.getInputStream()) {
+            byte[] bytes = new byte[1024];
+            int length;
+            while ((length = inputStream.read(bytes)) >= 0) {
+                zipOut.write(bytes, 0, length);
+            }
+        }
+        zipOut.closeEntry();
     }
-    zipOut.closeEntry();
-  }
 
-  private Map<String, InputStreamResource> getCSVsFromTables() {
-    return null;
-  }
-
-  @Override
-  public InputStreamResource createCsvZip() throws IOException {
-    Map<String, InputStreamResource> files = getCSVsFromTables();
-    ByteArrayOutputStream zipStream = new ByteArrayOutputStream();
-    try (ZipOutputStream zipOut = new ZipOutputStream(zipStream)) {
-      for (Map.Entry<String, InputStreamResource> entry : files.entrySet()) {
-        addToZip(zipOut, entry.getKey(), entry.getValue());
-      }
+    private Map<String, InputStreamResource> getCSVsFromTables() {
+        return null;
     }
-    return new InputStreamResource(new ByteArrayInputStream(zipStream.toByteArray()));
-  }
 
-  @Override
-  public InputStreamResource createPdfZip() throws IOException {
-    return null;
-  }
+    @Override
+    public InputStreamResource createCsvZip() throws IOException {
+        Map<String, InputStreamResource> files = getCSVsFromTables();
+        ByteArrayOutputStream zipStream = new ByteArrayOutputStream();
+        try (ZipOutputStream zipOut = new ZipOutputStream(zipStream)) {
+            for (Map.Entry<String, InputStreamResource> entry : files.entrySet()) {
+                addToZip(zipOut, entry.getKey(), entry.getValue());
+            }
+        }
+        return new InputStreamResource(new ByteArrayInputStream(zipStream.toByteArray()));
+    }
+
+    @Override
+    public InputStreamResource createPdfZip() throws IOException {
+        return null;
+    }
 }

--- a/src/main/java/com/sarapis/orservice/service/LanguageService.java
+++ b/src/main/java/com/sarapis/orservice/service/LanguageService.java
@@ -7,11 +7,11 @@ import java.util.List;
 public interface LanguageService {
     List<LanguageDTO> getAllLanguages();
 
-    LanguageDTO getLanguageById(String id);
+    LanguageDTO getLanguageById(String languageId);
 
     LanguageDTO createLanguage(LanguageDTO languageDTO);
 
-    LanguageDTO updateLanguage(String id, LanguageDTO languageDTO);
+    LanguageDTO updateLanguage(String languageId, LanguageDTO languageDTO);
 
-    void deleteLanguage(String id);
+    void deleteLanguage(String languageId);
 }

--- a/src/main/java/com/sarapis/orservice/service/LanguageServiceImpl.java
+++ b/src/main/java/com/sarapis/orservice/service/LanguageServiceImpl.java
@@ -1,43 +1,36 @@
 package com.sarapis.orservice.service;
 
-import com.sarapis.orservice.dto.AttributeDTO;
 import com.sarapis.orservice.dto.LanguageDTO;
-import com.sarapis.orservice.dto.MetadataDTO;
-import com.sarapis.orservice.entity.Attribute;
 import com.sarapis.orservice.entity.Language;
-import com.sarapis.orservice.entity.Metadata;
-import com.sarapis.orservice.repository.AttributeRepository;
 import com.sarapis.orservice.repository.LanguageRepository;
-import com.sarapis.orservice.repository.MetadataRepository;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 
 @Service
-public class LanguageServiceImpl implements LanguageService{
+public class LanguageServiceImpl implements LanguageService {
     private final LanguageRepository languageRepository;
-    private final AttributeRepository attributeRepository;
-    private final MetadataRepository metadataRepository;
+    private final AttributeService attributeService;
+    private final MetadataService metadataService;
 
-    public LanguageServiceImpl(LanguageRepository languageRepository, AttributeRepository attributeRepository, MetadataRepository metadataRepository) {
+    public LanguageServiceImpl(LanguageRepository languageRepository,
+                               AttributeService attributeService,
+                               MetadataService metadataService) {
         this.languageRepository = languageRepository;
-        this.attributeRepository = attributeRepository;
-        this.metadataRepository = metadataRepository;
+        this.attributeService = attributeService;
+        this.metadataService = metadataService;
     }
 
     @Override
     public List<LanguageDTO> getAllLanguages() {
-        List<LanguageDTO> languageDTOs = this.languageRepository.findAll()
-                .stream()
-                .map(Language::toDTO)
-                .toList();
+        List<LanguageDTO> languageDTOs = this.languageRepository.findAll().stream().map(Language::toDTO).toList();
         languageDTOs.forEach(this::addRelatedData);
         return languageDTOs;
     }
 
     @Override
-    public LanguageDTO getLanguageById(String id) {
-        Language language = this.languageRepository.findById(id)
+    public LanguageDTO getLanguageById(String languageId) {
+        Language language = this.languageRepository.findById(languageId)
                 .orElseThrow(() -> new RuntimeException("Language not found."));
         LanguageDTO languageDTO = language.toDTO();
         this.addRelatedData(languageDTO);
@@ -46,56 +39,39 @@ public class LanguageServiceImpl implements LanguageService{
 
     @Override
     public LanguageDTO createLanguage(LanguageDTO languageDTO) {
-        Language language = this.languageRepository.save(languageDTO.toEntity());
+        Language language = this.languageRepository.save(languageDTO.toEntity(null, null, null));
+        languageDTO.getAttributes()
+                .forEach(attributeDTO -> this.attributeService.createAttribute(language.getId(), attributeDTO));
+        languageDTO.getMetadata().forEach(e -> this.metadataService.createMetadata(language.getId(), e));
 
-        for (AttributeDTO attributeDTO : languageDTO.getAttributes()) {
-            this.attributeRepository.save(attributeDTO.toEntity(languageDTO.getId()));
-        }
-
-        for (MetadataDTO metadataDTO : languageDTO.getMetadata()) {
-            this.metadataRepository.save(metadataDTO.toEntity(languageDTO.getId()));
-        }
-
-        LanguageDTO savedLanguageDTO = this.languageRepository.save(language).toDTO();
-        this.addRelatedData(savedLanguageDTO);
-        return savedLanguageDTO;
+        Language createdLanguage = this.languageRepository.save(language);
+        return this.getLanguageById(createdLanguage.getId());
     }
 
     @Override
-    public LanguageDTO updateLanguage(String id, LanguageDTO languageDTO) {
-        Language oldLanguage = this.languageRepository.findById(id)
+    public LanguageDTO updateLanguage(String languageId, LanguageDTO languageDTO) {
+        Language language = this.languageRepository.findById(languageId)
                 .orElseThrow(() -> new RuntimeException("Language not found."));
 
-        oldLanguage.setName(languageDTO.getName());
-        oldLanguage.setCode(languageDTO.getCode());
-        oldLanguage.setNote(languageDTO.getNote());
+        language.setName(languageDTO.getName());
+        language.setCode(languageDTO.getCode());
+        language.setNote(languageDTO.getNote());
 
-        Language updatedLanguage = this.languageRepository.save(oldLanguage);
-        return updatedLanguage.toDTO();
+        Language updatedLanguage = this.languageRepository.save(language);
+        return this.getLanguageById(updatedLanguage.getId());
     }
 
     @Override
-    public void deleteLanguage(String id) {
-        Language language = this.languageRepository.findById(id)
+    public void deleteLanguage(String languageId) {
+        Language language = this.languageRepository.findById(languageId)
                 .orElseThrow(() -> new RuntimeException("Language not found."));
-
-        this.languageRepository.deleteAttributes(language.getId());
-        this.languageRepository.deleteMetadata(language.getId());
+        this.attributeService.deleteRelatedAttributes(language.getId());
+        this.metadataService.deleteRelatedMetadata(language.getId());
         this.languageRepository.delete(language);
     }
 
     private void addRelatedData(LanguageDTO languageDTO) {
-        List<AttributeDTO> attributes = this.languageRepository.getAttributes(languageDTO.getId())
-                .stream()
-                .map(Attribute::toDTO)
-                .toList();
-
-        List<MetadataDTO> metadata = this.languageRepository.getMetadata(languageDTO.getId())
-                .stream()
-                .map(Metadata::toDTO)
-                .toList();
-
-        languageDTO.getAttributes().addAll(attributes);
-        languageDTO.getMetadata().addAll(metadata);
+        languageDTO.getAttributes().addAll(this.attributeService.getRelatedAttributes(languageDTO.getId()));
+        languageDTO.getMetadata().addAll(this.metadataService.getRelatedMetadata(languageDTO.getId()));
     }
 }

--- a/src/main/java/com/sarapis/orservice/service/LocationService.java
+++ b/src/main/java/com/sarapis/orservice/service/LocationService.java
@@ -7,7 +7,7 @@ import java.util.List;
 public interface LocationService {
     List<LocationDTO> getAllLocations();
 
-    LocationDTO getLocation(String locationId);
+    LocationDTO getLocationById(String locationId);
 
     LocationDTO createLocation(LocationDTO locationDTO);
 

--- a/src/main/java/com/sarapis/orservice/service/LocationService.java
+++ b/src/main/java/com/sarapis/orservice/service/LocationService.java
@@ -1,0 +1,17 @@
+package com.sarapis.orservice.service;
+
+import com.sarapis.orservice.dto.LocationDTO;
+
+import java.util.List;
+
+public interface LocationService {
+    List<LocationDTO> getAllLocations();
+
+    LocationDTO getLocation(String locationId);
+
+    LocationDTO createLocation(LocationDTO locationDTO);
+
+    LocationDTO updateLocation(String locationId, LocationDTO locationDTO);
+
+    void deleteLocation(String locationId);
+}

--- a/src/main/java/com/sarapis/orservice/service/LocationServiceImpl.java
+++ b/src/main/java/com/sarapis/orservice/service/LocationServiceImpl.java
@@ -1,0 +1,87 @@
+package com.sarapis.orservice.service;
+
+import com.sarapis.orservice.dto.LocationDTO;
+import com.sarapis.orservice.entity.core.Location;
+import com.sarapis.orservice.repository.LocationRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class LocationServiceImpl implements LocationService {
+    private final LocationRepository locationRepository;
+    private final AttributeService attributeService;
+    private final MetadataService metadataService;
+
+    @Autowired
+    public LocationServiceImpl(LocationRepository locationRepository,
+                               AttributeService attributeService,
+                               MetadataService metadataService) {
+        this.locationRepository = locationRepository;
+        this.attributeService = attributeService;
+        this.metadataService = metadataService;
+    }
+
+    @Override
+    public List<LocationDTO> getAllLocations() {
+        List<LocationDTO> locationDTOs = this.locationRepository.findAll()
+                .stream().map(Location::toDTO).toList();
+        locationDTOs.forEach(this::addRelatedData);
+        return locationDTOs;
+    }
+
+    @Override
+    public LocationDTO getLocation(String locationId) {
+        Location location = this.locationRepository.findById(locationId)
+                .orElseThrow(() -> new RuntimeException("Location not found"));
+        LocationDTO locationDTO = location.toDTO();
+        this.addRelatedData(locationDTO);
+        return locationDTO;
+    }
+
+    @Override
+    public LocationDTO createLocation(LocationDTO locationDTO) {
+        Location location = locationDTO.toEntity(null);
+        locationDTO.getAttributes()
+                .forEach(attributeDTO -> this.attributeService.createAttribute(location.getId(), attributeDTO));
+        locationDTO.getMetadata().forEach(e -> this.metadataService.createMetadata(locationDTO.getId(), e));
+
+        Location createdLocation = this.locationRepository.save(location);
+        return this.getLocation(location.getId());
+    }
+
+    @Override
+    public LocationDTO updateLocation(String locationId, LocationDTO locationDTO) {
+        Location location = this.locationRepository.findById(locationId)
+                .orElseThrow(() -> new RuntimeException("Location not found"));
+
+        location.setLocationType(locationDTO.getLocationType());
+        location.setUrl(locationDTO.getUrl());
+        location.setName(locationDTO.getName());
+        location.setAlternateName(locationDTO.getAlternateName());
+        location.setDescription(locationDTO.getDescription());
+        location.setTransportation(locationDTO.getTransportation());
+        location.setLatitude(locationDTO.getLatitude());
+        location.setLongitude(locationDTO.getLongitude());
+        location.setExternalIdentifier(locationDTO.getExternalIdentifier());
+        location.setExternalIdentifierType(locationDTO.getExternalIdentifierType());
+
+        Location updatedLocation = this.locationRepository.save(location);
+        return this.getLocation(updatedLocation.getId());
+    }
+
+    @Override
+    public void deleteLocation(String locationId) {
+        Location location = this.locationRepository.findById(locationId)
+                .orElseThrow(() -> new RuntimeException("Location not found"));
+        this.attributeService.deleteRelatedAttributes(location.getId());
+        this.metadataService.deleteRelatedMetadata(location.getId());
+        this.locationRepository.delete(location);
+    }
+
+    private void addRelatedData(LocationDTO locationDTO) {
+        locationDTO.getAttributes().addAll(this.attributeService.getRelatedAttributes(locationDTO.getId()));
+        locationDTO.getMetadata().addAll(this.metadataService.getRelatedMetadata(locationDTO.getId()));
+    }
+}

--- a/src/main/java/com/sarapis/orservice/service/MetadataService.java
+++ b/src/main/java/com/sarapis/orservice/service/MetadataService.java
@@ -1,0 +1,21 @@
+package com.sarapis.orservice.service;
+
+import com.sarapis.orservice.dto.MetadataDTO;
+
+import java.util.List;
+
+public interface MetadataService {
+    List<MetadataDTO> getAllMetadata();
+
+    List<MetadataDTO> getRelatedMetadata(String resourceId);
+
+    MetadataDTO getMetadata(String metadataId);
+
+    MetadataDTO createMetadata(String resourceId, MetadataDTO metadataDTO);
+
+    MetadataDTO updateMetadata(String metadataId, String resourceId, MetadataDTO metadataDTO);
+
+    void deleteMetadata(String metadataId);
+
+    void deleteRelatedMetadata(String resourceId);
+}

--- a/src/main/java/com/sarapis/orservice/service/MetadataServiceImpl.java
+++ b/src/main/java/com/sarapis/orservice/service/MetadataServiceImpl.java
@@ -1,0 +1,72 @@
+package com.sarapis.orservice.service;
+
+import com.sarapis.orservice.dto.MetadataDTO;
+import com.sarapis.orservice.entity.Metadata;
+import com.sarapis.orservice.repository.MetadataRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class MetadataServiceImpl implements MetadataService {
+    private final MetadataRepository metadataRepository;
+
+    @Autowired
+    public MetadataServiceImpl(MetadataRepository metadataRepository) {
+        this.metadataRepository = metadataRepository;
+    }
+
+    @Override
+    public List<MetadataDTO> getAllMetadata() {
+        return this.metadataRepository.findAll()
+                .stream().map(Metadata::toDTO).toList();
+    }
+
+    @Override
+    public List<MetadataDTO> getRelatedMetadata(String resourceId) {
+        return this.metadataRepository.getRelatedMetadata(resourceId)
+                .stream().map(Metadata::toDTO).toList();
+    }
+
+    @Override
+    public MetadataDTO getMetadata(String metadataId) {
+        Metadata metadata = this.metadataRepository.findById(metadataId)
+                .orElseThrow(() -> new RuntimeException("Metadata not found."));
+        return metadata.toDTO();
+    }
+
+    @Override
+    public MetadataDTO createMetadata(String resourceId, MetadataDTO metadataDTO) {
+        return this.metadataRepository.save(metadataDTO.toEntity(resourceId)).toDTO();
+    }
+
+    @Override
+    public MetadataDTO updateMetadata(String metadataId, String resourceId, MetadataDTO metadataDTO) {
+        Metadata metadata = this.metadataRepository.findById(metadataId)
+                .orElseThrow(() -> new RuntimeException("Metadata not found."));
+
+        metadata.setResourceId(resourceId);
+        metadata.setResourceType(metadataDTO.getResourceType());
+        metadata.setLastActionDate(metadataDTO.getLastActionDate());
+        metadata.setLastActionType(metadataDTO.getLastActionType());
+        metadata.setFieldName(metadataDTO.getFieldName());
+        metadata.setPreviousValue(metadataDTO.getPreviousValue());
+        metadata.setReplacementValue(metadataDTO.getReplacementValue());
+        metadata.setUpdatedBy(metadataDTO.getUpdatedBy());
+
+        return this.metadataRepository.save(metadataDTO.toEntity(metadataId)).toDTO();
+    }
+
+    @Override
+    public void deleteMetadata(String metadataId) {
+        Metadata metadata = this.metadataRepository.findById(metadataId)
+                .orElseThrow(() -> new RuntimeException("Metadata not found."));
+        this.metadataRepository.delete(metadata);
+    }
+
+    @Override
+    public void deleteRelatedMetadata(String resourceId) {
+        this.metadataRepository.deleteById(resourceId);
+    }
+}

--- a/src/main/java/com/sarapis/orservice/service/OrganizationService.java
+++ b/src/main/java/com/sarapis/orservice/service/OrganizationService.java
@@ -1,21 +1,20 @@
 package com.sarapis.orservice.service;
 
 import com.sarapis.orservice.dto.OrganizationDTO;
-import com.sarapis.orservice.entity.core.Organization;
 import java.io.ByteArrayInputStream;
 import java.util.List;
 
 public interface OrganizationService {
-  List<OrganizationDTO> getAllOrganizations();
+    List<OrganizationDTO> getAllOrganizations();
 
-  OrganizationDTO getOrganizationById(String id);
+    OrganizationDTO getOrganizationById(String organizationId);
 
-  OrganizationDTO createOrganization(OrganizationDTO organizationDTO);
+    OrganizationDTO createOrganization(OrganizationDTO organizationDTO);
 
-  OrganizationDTO updateOrganization(String id, OrganizationDTO organizationDTO);
+    OrganizationDTO updateOrganization(String organizationId, OrganizationDTO organizationDTO);
 
-  void deleteOrganization(String id);
+    void deleteOrganization(String organizationId);
 
-  ByteArrayInputStream loadCSV();
+    ByteArrayInputStream loadCSV();
 
 }

--- a/src/main/java/com/sarapis/orservice/service/PhoneService.java
+++ b/src/main/java/com/sarapis/orservice/service/PhoneService.java
@@ -7,11 +7,11 @@ import java.util.List;
 public interface PhoneService {
     List<PhoneDTO> getAllPhones();
 
-    PhoneDTO getPhoneById(String id);
+    PhoneDTO getPhoneById(String phoneId);
 
     PhoneDTO createPhone(PhoneDTO phoneDTO);
 
-    PhoneDTO updatePhone(String id, PhoneDTO phoneDTO);
+    PhoneDTO updatePhone(String phoneId, PhoneDTO phoneDTO);
 
-    void deletePhone(String id);
+    void deletePhone(String phoneId);
 }

--- a/src/main/java/com/sarapis/orservice/service/PhoneServiceImpl.java
+++ b/src/main/java/com/sarapis/orservice/service/PhoneServiceImpl.java
@@ -1,8 +1,12 @@
 package com.sarapis.orservice.service;
 
 import com.sarapis.orservice.dto.PhoneDTO;
+import com.sarapis.orservice.entity.Contact;
 import com.sarapis.orservice.entity.Phone;
-import com.sarapis.orservice.repository.PhoneRepository;
+import com.sarapis.orservice.entity.core.Location;
+import com.sarapis.orservice.entity.core.Organization;
+import com.sarapis.orservice.entity.core.ServiceAtLocation;
+import com.sarapis.orservice.repository.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -11,14 +15,29 @@ import java.util.List;
 @Service
 public class PhoneServiceImpl implements PhoneService {
     private final PhoneRepository phoneRepository;
+    private final LocationRepository locationRepository;
+    private final ServiceRepository serviceRepository;
+    private final OrganizationRepository organizationRepository;
+    private final ContactRepository contactRepository;
+    private final ServiceAtLocationRepository serviceAtLocationRepository;
     private final AttributeService attributeService;
     private final MetadataService metadataService;
 
     @Autowired
     public PhoneServiceImpl(PhoneRepository phoneRepository,
+                            LocationRepository locationRepository,
+                            ServiceRepository serviceRepository,
+                            OrganizationRepository organizationRepository,
+                            ContactRepository contactRepository,
+                            ServiceAtLocationRepository serviceAtLocationRepository,
                             AttributeService attributeService,
                             MetadataService metadataService) {
         this.phoneRepository = phoneRepository;
+        this.locationRepository = locationRepository;
+        this.serviceRepository = serviceRepository;
+        this.organizationRepository = organizationRepository;
+        this.contactRepository = contactRepository;
+        this.serviceAtLocationRepository = serviceAtLocationRepository;
         this.attributeService = attributeService;
         this.metadataService = metadataService;
     }
@@ -42,7 +61,34 @@ public class PhoneServiceImpl implements PhoneService {
 
     @Override
     public PhoneDTO createPhone(PhoneDTO phoneDTO) {
-        Phone phone = this.phoneRepository.save(phoneDTO.toEntity(null, null, null, null, null));
+        Location location = null;
+        com.sarapis.orservice.entity.core.Service service = null;
+        Organization organization = null;
+        Contact contact = null;
+        ServiceAtLocation serviceAtLocation = null;
+
+        if (phoneDTO.getLocationId() != null) {
+            location = this.locationRepository.findById(phoneDTO.getLocationId())
+                    .orElseThrow(() -> new RuntimeException("Location not found."));
+        }
+        if (phoneDTO.getServiceId() != null) {
+            service = this.serviceRepository.findById(phoneDTO.getServiceId())
+                    .orElseThrow(() -> new RuntimeException("Service not found."));
+        }
+        if (phoneDTO.getOrganizationId() != null) {
+            organization = this.organizationRepository.findById(phoneDTO.getOrganizationId())
+                    .orElseThrow(() -> new RuntimeException("Organization not found."));
+        }
+        if (phoneDTO.getContactId() != null) {
+            contact = this.contactRepository.findById(phoneDTO.getContactId())
+                    .orElseThrow(() -> new RuntimeException("Contact not found."));
+        }
+        if (phoneDTO.getServiceAtLocationId() != null) {
+            serviceAtLocation = this.serviceAtLocationRepository.findById(phoneDTO.getServiceAtLocationId())
+                    .orElseThrow(() -> new RuntimeException("Service at location not found."));
+        }
+
+        Phone phone = this.phoneRepository.save(phoneDTO.toEntity(location, service, organization, contact, serviceAtLocation));
         phoneDTO.getAttributes()
                 .forEach(attributeDTO -> this.attributeService.createAttribute(phone.getId(), attributeDTO));
         phoneDTO.getMetadata().forEach(e -> this.metadataService.createMetadata(phone.getId(), e));

--- a/src/main/java/com/sarapis/orservice/service/ProgramService.java
+++ b/src/main/java/com/sarapis/orservice/service/ProgramService.java
@@ -4,13 +4,13 @@ import com.sarapis.orservice.dto.ProgramDTO;
 import java.util.List;
 
 public interface ProgramService {
-  List<ProgramDTO> getAllPrograms();
+    List<ProgramDTO> getAllPrograms();
 
-  ProgramDTO getProgramDTOById(String id);
+    ProgramDTO getProgramDTOById(String programId);
 
-  ProgramDTO createProgram(ProgramDTO programDTO);
+    ProgramDTO createProgram(ProgramDTO programDTO);
 
-  ProgramDTO updateProgram(String id, ProgramDTO programDTO);
+    ProgramDTO updateProgram(String programId, ProgramDTO programDTO);
 
-  void deleteProgram(String id);
+    void deleteProgram(String programId);
 }

--- a/src/main/java/com/sarapis/orservice/service/ScheduleService.java
+++ b/src/main/java/com/sarapis/orservice/service/ScheduleService.java
@@ -7,11 +7,11 @@ import java.util.List;
 public interface ScheduleService {
     List<ScheduleDTO> getAllSchedules();
 
-    ScheduleDTO getScheduleById(String id);
+    ScheduleDTO getScheduleById(String scheduleId);
 
     ScheduleDTO createSchedule(ScheduleDTO scheduleDTO);
 
-    ScheduleDTO updateSchedule(String id, ScheduleDTO scheduleDTO);
+    ScheduleDTO updateSchedule(String scheduleId, ScheduleDTO scheduleDTO);
 
-    void deleteSchedule(String id);
+    void deleteSchedule(String scheduleId);
 }

--- a/src/main/java/com/sarapis/orservice/service/ServiceAreaService.java
+++ b/src/main/java/com/sarapis/orservice/service/ServiceAreaService.java
@@ -1,20 +1,17 @@
 package com.sarapis.orservice.service;
 
 import com.sarapis.orservice.dto.ServiceAreaDTO;
-import com.sarapis.orservice.dto.ServiceDTO;
-import org.springframework.stereotype.Service;
 
 import java.util.List;
 
 public interface ServiceAreaService {
-
     List<ServiceAreaDTO> getAllServiceAreas();
 
-    ServiceAreaDTO getServiceAreaById(String id);
+    ServiceAreaDTO getServiceAreaById(String serviceAreaId);
 
     ServiceAreaDTO createServiceArea(ServiceAreaDTO serviceAreaDTO);
 
-    ServiceAreaDTO updateServiceArea(String id, ServiceAreaDTO serviceAreaDTO);
+    ServiceAreaDTO updateServiceArea(String serviceAreaId, ServiceAreaDTO serviceAreaDTO);
 
-    void deleteServiceArea(String id);
+    void deleteServiceArea(String serviceAreaId);
 }

--- a/src/main/java/com/sarapis/orservice/service/ServiceAreaServiceImpl.java
+++ b/src/main/java/com/sarapis/orservice/service/ServiceAreaServiceImpl.java
@@ -1,13 +1,7 @@
 package com.sarapis.orservice.service;
 
-import com.sarapis.orservice.dto.AttributeDTO;
-import com.sarapis.orservice.dto.MetadataDTO;
 import com.sarapis.orservice.dto.ServiceAreaDTO;
-import com.sarapis.orservice.entity.Attribute;
-import com.sarapis.orservice.entity.Metadata;
 import com.sarapis.orservice.entity.ServiceArea;
-import com.sarapis.orservice.repository.AttributeRepository;
-import com.sarapis.orservice.repository.MetadataRepository;
 import com.sarapis.orservice.repository.ServiceAreaRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -15,31 +9,32 @@ import org.springframework.stereotype.Service;
 import java.util.List;
 
 @Service
-public class ServiceAreaServiceImpl implements ServiceAreaService{
+public class ServiceAreaServiceImpl implements ServiceAreaService {
     private final ServiceAreaRepository serviceAreaRepository;
-    private final AttributeRepository attributeRepository;
-    private final MetadataRepository metadataRepository;
+    private final AttributeService attributeService;
+    private final MetadataService metadataService;
 
     @Autowired
     public ServiceAreaServiceImpl(ServiceAreaRepository serviceAreaRepository,
-                                  AttributeRepository attributeRepository,
-                                  MetadataRepository metadataRepository) {
+                                  AttributeService attributeService,
+                                  MetadataService metadataService) {
         this.serviceAreaRepository = serviceAreaRepository;
-        this.attributeRepository = attributeRepository;
-        this.metadataRepository = metadataRepository;
+        this.attributeService = attributeService;
+        this.metadataService = metadataService;
     }
 
     @Override
     public List<ServiceAreaDTO> getAllServiceAreas() {
-        List<ServiceAreaDTO> serviceAreaDTOs = this.serviceAreaRepository.findAll().stream().map(ServiceArea::toDTO).toList();
+        List<ServiceAreaDTO> serviceAreaDTOs = this.serviceAreaRepository.findAll().stream().map(ServiceArea::toDTO)
+                .toList();
         serviceAreaDTOs.forEach(this::addRelatedData);
         return serviceAreaDTOs;
     }
 
     @Override
-    public ServiceAreaDTO getServiceAreaById(String id) {
-        ServiceArea serviceArea = this.serviceAreaRepository.findById(id)
-                .orElseThrow(() -> new RuntimeException("Service Area not found."));
+    public ServiceAreaDTO getServiceAreaById(String serviceAreaId) {
+        ServiceArea serviceArea = this.serviceAreaRepository.findById(serviceAreaId)
+                .orElseThrow(() -> new RuntimeException("Service area not found."));
         ServiceAreaDTO serviceAreaDTO = serviceArea.toDTO();
         this.addRelatedData(serviceAreaDTO);
         return serviceAreaDTO;
@@ -47,47 +42,42 @@ public class ServiceAreaServiceImpl implements ServiceAreaService{
 
     @Override
     public ServiceAreaDTO createServiceArea(ServiceAreaDTO serviceAreaDTO) {
-        ServiceArea serviceArea = this.serviceAreaRepository.save(serviceAreaDTO.toEntity());
+        ServiceArea serviceArea = this.serviceAreaRepository.save(serviceAreaDTO.toEntity(null, null));
+        serviceAreaDTO.getAttributes()
+                .forEach(attributeDTO -> this.attributeService.createAttribute(serviceArea.getId(), attributeDTO));
+        serviceAreaDTO.getMetadata().forEach(e -> this.metadataService.createMetadata(serviceArea.getId(), e));
 
-        for(AttributeDTO attributeDTO: serviceAreaDTO.getAttributes()) {
-            this.attributeRepository.save(attributeDTO.toEntity(serviceArea.getId()));
-        }
-
-        for (MetadataDTO metadataDTO : serviceAreaDTO.getMetadata()) {
-            this.metadataRepository.save(metadataDTO.toEntity(serviceArea.getId()));
-        }
-
-        ServiceAreaDTO savedServiceAreaDTO = this.serviceAreaRepository.save(serviceArea).toDTO();
-        this.addRelatedData(serviceAreaDTO);
-        return savedServiceAreaDTO;
+        ServiceArea createdServiceArea = this.serviceAreaRepository.save(serviceArea);
+        return this.getServiceAreaById(createdServiceArea.getId());
     }
 
     @Override
-    public ServiceAreaDTO updateServiceArea(String id, ServiceAreaDTO serviceAreaDTO) {
-        ServiceArea oldServiceArea = this.serviceAreaRepository.findById(id)
+    public ServiceAreaDTO updateServiceArea(String serviceAreaId, ServiceAreaDTO serviceAreaDTO) {
+        ServiceArea serviceArea = this.serviceAreaRepository.findById(serviceAreaId)
                 .orElseThrow(() -> new RuntimeException("ServiceArea not found"));
-        oldServiceArea.setId(serviceAreaDTO.getId());
-        oldServiceArea.setName(serviceAreaDTO.getName());
-        oldServiceArea.setDescription(serviceAreaDTO.getDescription());
-        oldServiceArea.setExtent(serviceAreaDTO.getExtent());
-        oldServiceArea.setExtentType(serviceAreaDTO.getExtentType());
-        oldServiceArea.setUri(serviceAreaDTO.getUri());
 
-        ServiceArea updatedServiceArea = this.serviceAreaRepository.save(oldServiceArea);
-        return updatedServiceArea.toDTO();
+        serviceArea.setId(serviceAreaDTO.getId());
+        serviceArea.setName(serviceAreaDTO.getName());
+        serviceArea.setDescription(serviceAreaDTO.getDescription());
+        serviceArea.setExtent(serviceAreaDTO.getExtent());
+        serviceArea.setExtentType(serviceAreaDTO.getExtentType());
+        serviceArea.setUri(serviceAreaDTO.getUri());
+
+        ServiceArea updatedServiceArea = this.serviceAreaRepository.save(serviceArea);
+        return this.getServiceAreaById(updatedServiceArea.getId());
     }
 
     @Override
-    public void deleteServiceArea(String id) {
-        ServiceArea serviceArea = this.serviceAreaRepository.findById(id)
+    public void deleteServiceArea(String serviceAreaId) {
+        ServiceArea serviceArea = this.serviceAreaRepository.findById(serviceAreaId)
                 .orElseThrow(() -> new RuntimeException("ServiceArea not found"));
-        this.serviceAreaRepository.deleteAttributes(serviceArea.getId());
-        this.serviceAreaRepository.deleteMetadata(serviceArea.getId());
+        this.attributeService.deleteRelatedAttributes(serviceArea.getId());
+        this.metadataService.deleteRelatedMetadata(serviceArea.getId());
         this.serviceAreaRepository.delete(serviceArea);
     }
 
     private void addRelatedData(ServiceAreaDTO serviceAreaDTO) {
-        serviceAreaDTO.getAttributes().addAll(this.serviceAreaRepository.getAttributes(serviceAreaDTO.getId()).stream().map(Attribute::toDTO).toList());
-        serviceAreaDTO.getMetadata().addAll(this.serviceAreaRepository.getMetadata(serviceAreaDTO.getId()).stream().map(Metadata::toDTO).toList());
+        serviceAreaDTO.getAttributes().addAll(this.attributeService.getRelatedAttributes(serviceAreaDTO.getId()));
+        serviceAreaDTO.getMetadata().addAll(this.metadataService.getRelatedMetadata(serviceAreaDTO.getId()));
     }
 }

--- a/src/main/java/com/sarapis/orservice/service/ServiceAtLocationService.java
+++ b/src/main/java/com/sarapis/orservice/service/ServiceAtLocationService.java
@@ -4,13 +4,13 @@ import com.sarapis.orservice.dto.ServiceAtLocationDTO;
 import java.util.List;
 
 public interface ServiceAtLocationService {
-  List<ServiceAtLocationDTO> getAllServicesAtLocation();
+    List<ServiceAtLocationDTO> getAllServicesAtLocation();
 
-  ServiceAtLocationDTO getServiceAtLocationById(String id);
+    ServiceAtLocationDTO getServiceAtLocationById(String serviceAtLocationId);
 
-  ServiceAtLocationDTO createServiceAtLocation(ServiceAtLocationDTO serviceAtLocationDTO);
+    ServiceAtLocationDTO createServiceAtLocation(ServiceAtLocationDTO serviceAtLocationDTO);
 
-  ServiceAtLocationDTO updateServiceAtLocation(String id, ServiceAtLocationDTO serviceAtLocationDTO);
+    ServiceAtLocationDTO updateServiceAtLocation(String serviceAtLocationId, ServiceAtLocationDTO serviceAtLocationDTO);
 
-  void deleteServiceAtLocation(String id);
+    void deleteServiceAtLocation(String serviceAtLocationId);
 }

--- a/src/main/java/com/sarapis/orservice/service/ServiceAtLocationServiceImpl.java
+++ b/src/main/java/com/sarapis/orservice/service/ServiceAtLocationServiceImpl.java
@@ -1,17 +1,7 @@
 package com.sarapis.orservice.service;
 
-import com.sarapis.orservice.dto.AttributeDTO;
-import com.sarapis.orservice.dto.ContactDTO;
-import com.sarapis.orservice.dto.MetadataDTO;
-import com.sarapis.orservice.dto.PhoneDTO;
-import com.sarapis.orservice.dto.ScheduleDTO;
-import com.sarapis.orservice.dto.ServiceAreaDTO;
 import com.sarapis.orservice.dto.ServiceAtLocationDTO;
-import com.sarapis.orservice.entity.Attribute;
-import com.sarapis.orservice.entity.Metadata;
 import com.sarapis.orservice.entity.core.ServiceAtLocation;
-import com.sarapis.orservice.repository.AttributeRepository;
-import com.sarapis.orservice.repository.MetadataRepository;
 import com.sarapis.orservice.repository.ServiceAtLocationRepository;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,91 +9,70 @@ import org.springframework.stereotype.Service;
 
 @Service
 public class ServiceAtLocationServiceImpl implements ServiceAtLocationService {
-  private final ServiceAtLocationRepository serviceAtLocationRepository;
-  private final AttributeRepository attributeRepository;
-  private final MetadataRepository metadataRepository;
+    private final ServiceAtLocationRepository serviceAtLocationRepository;
+    private final AttributeService attributeService;
+    private final MetadataService metadataService;
 
-  @Autowired
-  public ServiceAtLocationServiceImpl(ServiceAtLocationRepository serviceAtLocationService, AttributeRepository attributeRepository, MetadataRepository metadataRepository) {
-    this.serviceAtLocationRepository = serviceAtLocationService;
-    this.attributeRepository = attributeRepository;
-    this.metadataRepository = metadataRepository;
-  }
-
-  @Override
-  public List<ServiceAtLocationDTO> getAllServicesAtLocation() {
-    List<ServiceAtLocationDTO> servLocsDTOs = this.serviceAtLocationRepository.findAll().stream()
-            .map(ServiceAtLocation::toDTO)
-            .toList();
-    servLocsDTOs.forEach(this::addRelatedData);
-    return servLocsDTOs;
-  }
-
-  @Override
-  public ServiceAtLocationDTO getServiceAtLocationById(String id) {
-    ServiceAtLocation servLoc = this.serviceAtLocationRepository.findById(id)
-            .orElseThrow(() -> new RuntimeException("Service At Location not found."));
-
-    ServiceAtLocationDTO servLocDTO = servLoc.toDTO();
-    this.addRelatedData(servLocDTO);
-    return servLocDTO;
-  }
-
-  @Override
-  public ServiceAtLocationDTO createServiceAtLocation(ServiceAtLocationDTO serviceAtLocationDTO) {
-    ServiceAtLocation servLoc = this.serviceAtLocationRepository.save(serviceAtLocationDTO.toEntity());
-
-    for (AttributeDTO attributeDTO : serviceAtLocationDTO.getAttributes()) {
-      this.attributeRepository.save(attributeDTO.toEntity(servLoc.getId()));
+    @Autowired
+    public ServiceAtLocationServiceImpl(ServiceAtLocationRepository serviceAtLocationService,
+                                        AttributeService attributeService,
+                                        MetadataService metadataService) {
+        this.serviceAtLocationRepository = serviceAtLocationService;
+        this.attributeService = attributeService;
+        this.metadataService = metadataService;
     }
 
-    for (MetadataDTO metadataDTO : serviceAtLocationDTO.getMetadata()) {
-      this.metadataRepository.save(metadataDTO.toEntity(servLoc.getId()));
+    @Override
+    public List<ServiceAtLocationDTO> getAllServicesAtLocation() {
+        List<ServiceAtLocationDTO> serviceAtLocationDTOs = this.serviceAtLocationRepository.findAll().stream()
+                .map(ServiceAtLocation::toDTO).toList();
+        serviceAtLocationDTOs.forEach(this::addRelatedData);
+        return serviceAtLocationDTOs;
     }
 
-    ServiceAtLocationDTO savedServLocDTO = this.serviceAtLocationRepository.save(servLoc).toDTO();
-    this.addRelatedData(savedServLocDTO);
-    return savedServLocDTO;
-  }
+    @Override
+    public ServiceAtLocationDTO getServiceAtLocationById(String serviceAtLocationId) {
+        ServiceAtLocation serviceAtLocation = this.serviceAtLocationRepository.findById(serviceAtLocationId)
+                .orElseThrow(() -> new RuntimeException("Service at location not found."));
+        ServiceAtLocationDTO servLocDTO = serviceAtLocation.toDTO();
+        this.addRelatedData(servLocDTO);
+        return servLocDTO;
+    }
 
-  @Override
-  public ServiceAtLocationDTO updateServiceAtLocation(String id,
-      ServiceAtLocationDTO serviceAtLocationDTO) {
-    ServiceAtLocation servLoc = this.serviceAtLocationRepository.findById(id)
-            .orElseThrow(() -> new RuntimeException("Service At Location not found"));
+    @Override
+    public ServiceAtLocationDTO createServiceAtLocation(ServiceAtLocationDTO serviceAtLocationDTO) {
+        ServiceAtLocation serviceAtLocation = this.serviceAtLocationRepository.save(serviceAtLocationDTO.toEntity(null, null));
+        serviceAtLocationDTO.getAttributes()
+                .forEach(attributeDTO -> this.attributeService.createAttribute(serviceAtLocation.getId(), attributeDTO));
+        serviceAtLocationDTO.getMetadata()
+                .forEach(e -> this.metadataService.createMetadata(serviceAtLocation.getId(), e));
 
-    servLoc.setDescription(serviceAtLocationDTO.getDescription());
-    servLoc.setServiceAreas(serviceAtLocationDTO.getServiceAreas().stream().map(ServiceAreaDTO::toEntity).toList());
-    servLoc.setContacts(serviceAtLocationDTO.getContacts().stream().map(ContactDTO::toEntity).toList());
-    servLoc.setPhones(serviceAtLocationDTO.getPhones().stream().map(PhoneDTO::toEntity).toList());
-    servLoc.setSchedules(serviceAtLocationDTO.getSchedules().stream().map(ScheduleDTO::toEntity).toList());
-    servLoc.setLocation(serviceAtLocationDTO.getLocation().toEntity());
+        ServiceAtLocation createdServiceAtLocation = this.serviceAtLocationRepository.save(serviceAtLocation);
+        return this.getServiceAtLocationById(createdServiceAtLocation.getId());
+    }
 
-    ServiceAtLocation updatedServLoc = this.serviceAtLocationRepository.save(servLoc);
-    return updatedServLoc.toDTO();
-  }
+    @Override
+    public ServiceAtLocationDTO updateServiceAtLocation(String serviceAtLocationId, ServiceAtLocationDTO serviceAtLocationDTO) {
+        ServiceAtLocation serviceAtLocation = this.serviceAtLocationRepository.findById(serviceAtLocationId)
+                .orElseThrow(() -> new RuntimeException("Service At Location not found"));
 
-  @Override
-  public void deleteServiceAtLocation(String id) {
-    ServiceAtLocation servLoc = this.serviceAtLocationRepository.findById(id)
-            .orElseThrow(() -> new RuntimeException("Service At Location not found."));
+        serviceAtLocation.setDescription(serviceAtLocationDTO.getDescription());
 
-    this.serviceAtLocationRepository.delete(servLoc);
-  }
+        ServiceAtLocation updatedServiceAtLocation = this.serviceAtLocationRepository.save(serviceAtLocation);
+        return this.getServiceAtLocationById(updatedServiceAtLocation.getId());
+    }
 
-  private void addRelatedData(ServiceAtLocationDTO serviceAtLocationDTO) {
-    String id = serviceAtLocationDTO.getId();
-    List<AttributeDTO> attributeDTOs = this.serviceAtLocationRepository.getAttributes(id)
-            .stream()
-            .map(Attribute::toDTO)
-            .toList();
+    @Override
+    public void deleteServiceAtLocation(String serviceAtLocationId) {
+        ServiceAtLocation serviceAtLocation = this.serviceAtLocationRepository.findById(serviceAtLocationId)
+                .orElseThrow(() -> new RuntimeException("Service At Location not found."));
+        this.attributeService.deleteAttribute(serviceAtLocation.getId());
+        this.metadataService.deleteMetadata(serviceAtLocation.getId());
+        this.serviceAtLocationRepository.delete(serviceAtLocation);
+    }
 
-    List<MetadataDTO> metadataDTOs = this.serviceAtLocationRepository.getMetadata(id)
-            .stream()
-            .map(Metadata::toDTO)
-            .toList();
-
-    serviceAtLocationDTO.getAttributes().addAll(attributeDTOs);
-    serviceAtLocationDTO.getMetadata().addAll(metadataDTOs);
-  }
+    private void addRelatedData(ServiceAtLocationDTO serviceAtLocationDTO) {
+        serviceAtLocationDTO.getAttributes().addAll(this.attributeService.getRelatedAttributes(serviceAtLocationDTO.getId()));
+        serviceAtLocationDTO.getMetadata().addAll(this.metadataService.getRelatedMetadata(serviceAtLocationDTO.getId()));
+    }
 }

--- a/src/main/java/com/sarapis/orservice/service/ServiceAtLocationServiceImpl.java
+++ b/src/main/java/com/sarapis/orservice/service/ServiceAtLocationServiceImpl.java
@@ -1,23 +1,33 @@
 package com.sarapis.orservice.service;
 
 import com.sarapis.orservice.dto.ServiceAtLocationDTO;
+import com.sarapis.orservice.entity.core.Location;
 import com.sarapis.orservice.entity.core.ServiceAtLocation;
+import com.sarapis.orservice.repository.LocationRepository;
 import com.sarapis.orservice.repository.ServiceAtLocationRepository;
-import java.util.List;
+import com.sarapis.orservice.repository.ServiceRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 public class ServiceAtLocationServiceImpl implements ServiceAtLocationService {
     private final ServiceAtLocationRepository serviceAtLocationRepository;
+    private final ServiceRepository serviceRepository;
+    private final LocationRepository locationRepository;
     private final AttributeService attributeService;
     private final MetadataService metadataService;
 
     @Autowired
     public ServiceAtLocationServiceImpl(ServiceAtLocationRepository serviceAtLocationService,
+                                        ServiceRepository serviceRepository,
+                                        LocationRepository locationRepository,
                                         AttributeService attributeService,
                                         MetadataService metadataService) {
         this.serviceAtLocationRepository = serviceAtLocationService;
+        this.serviceRepository = serviceRepository;
+        this.locationRepository = locationRepository;
         this.attributeService = attributeService;
         this.metadataService = metadataService;
     }
@@ -41,7 +51,19 @@ public class ServiceAtLocationServiceImpl implements ServiceAtLocationService {
 
     @Override
     public ServiceAtLocationDTO createServiceAtLocation(ServiceAtLocationDTO serviceAtLocationDTO) {
-        ServiceAtLocation serviceAtLocation = this.serviceAtLocationRepository.save(serviceAtLocationDTO.toEntity(null, null));
+        com.sarapis.orservice.entity.core.Service service = null;
+        Location location = null;
+
+        if (serviceAtLocationDTO.getServiceId() != null) {
+            service = this.serviceRepository.findById(serviceAtLocationDTO.getServiceId())
+                    .orElseThrow(() -> new RuntimeException("Service not found."));
+        }
+        if (serviceAtLocationDTO.getLocationId() != null) {
+            location = this.locationRepository.findById(serviceAtLocationDTO.getLocationId())
+                    .orElseThrow(() -> new RuntimeException("Service at location not found."));
+        }
+
+        ServiceAtLocation serviceAtLocation = this.serviceAtLocationRepository.save(serviceAtLocationDTO.toEntity(service, location));
         serviceAtLocationDTO.getAttributes()
                 .forEach(attributeDTO -> this.attributeService.createAttribute(serviceAtLocation.getId(), attributeDTO));
         serviceAtLocationDTO.getMetadata()

--- a/src/main/java/com/sarapis/orservice/service/ServiceService.java
+++ b/src/main/java/com/sarapis/orservice/service/ServiceService.java
@@ -4,13 +4,13 @@ import com.sarapis.orservice.dto.ServiceDTO;
 import java.util.List;
 
 public interface ServiceService {
-  List<ServiceDTO> getAllServices();
+    List<ServiceDTO> getAllServices();
 
-  ServiceDTO getServiceById(String id);
+    ServiceDTO getServiceById(String serviceId);
 
-  ServiceDTO createService(ServiceDTO serviceDTO);
+    ServiceDTO createService(ServiceDTO serviceDTO);
 
-  ServiceDTO updateService(String id, ServiceDTO serviceDTO);
+    ServiceDTO updateService(String serviceId, ServiceDTO serviceDTO);
 
-  void deleteService(String id);
+    void deleteService(String serviceId);
 }

--- a/src/main/java/com/sarapis/orservice/service/ServiceServiceImpl.java
+++ b/src/main/java/com/sarapis/orservice/service/ServiceServiceImpl.java
@@ -2,49 +2,75 @@ package com.sarapis.orservice.service;
 
 import com.sarapis.orservice.dto.ServiceDTO;
 import com.sarapis.orservice.repository.ServiceRepository;
+
 import java.util.List;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 @Service
 public class ServiceServiceImpl implements ServiceService {
-  private final ServiceRepository serviceRepository;
+    private final ServiceRepository serviceRepository;
+    private final AttributeService attributeService;
+    private final MetadataService metadataService;
 
-  @Autowired
-  public ServiceServiceImpl(ServiceRepository serviceRepository) {
-    this.serviceRepository = serviceRepository;
-  }
+    @Autowired
+    public ServiceServiceImpl(ServiceRepository serviceRepository,
+                              AttributeService attributeService,
+                              MetadataService metadataService) {
+        this.serviceRepository = serviceRepository;
+        this.attributeService = attributeService;
+        this.metadataService = metadataService;
+    }
 
-  private ServiceDTO mapToDTO(ServiceDTO serviceDTO) {
-    return null;
-  }
+    @Override
+    public List<ServiceDTO> getAllServices() {
+        List<ServiceDTO> serviceDTOs = this.serviceRepository.findAll().stream()
+                .map(com.sarapis.orservice.entity.core.Service::toDTO).toList();
+        serviceDTOs.forEach(this::addRelatedData);
+        return serviceDTOs;
+    }
 
-  private com.sarapis.orservice.entity.core.Service mapToEntity(ServiceDTO serviceDTO) {
-    return null;
-  }
+    @Override
+    public ServiceDTO getServiceById(String serviceId) {
+        com.sarapis.orservice.entity.core.Service service = this.serviceRepository.findById(serviceId)
+                .orElseThrow(() -> new RuntimeException("Service not found."));
+        ServiceDTO serviceDTO = service.toDTO();
+        this.addRelatedData(serviceDTO);
+        return serviceDTO;
+    }
 
-  @Override
-  public List<ServiceDTO> getAllServices() {
-    return List.of();
-  }
+    @Override
+    public ServiceDTO createService(ServiceDTO serviceDTO) {
+        com.sarapis.orservice.entity.core.Service service = serviceDTO.toEntity(null, null);
+        serviceDTO.getAttributes()
+                .forEach(attributeDTO -> this.attributeService.createAttribute(service.getId(), attributeDTO));
+        serviceDTO.getMetadata().forEach(e -> this.metadataService.createMetadata(service.getId(), e));
 
-  @Override
-  public ServiceDTO getServiceById(String id) {
-    return null;
-  }
+        com.sarapis.orservice.entity.core.Service createdService = this.serviceRepository.save(service);
+        return this.getServiceById(createdService.getId());
+    }
 
-  @Override
-  public ServiceDTO createService(ServiceDTO serviceDTO) {
-    return null;
-  }
+    @Override
+    public ServiceDTO updateService(String serviceId, ServiceDTO serviceDTO) {
+        com.sarapis.orservice.entity.core.Service service = this.serviceRepository.findById(serviceId)
+                .orElseThrow(() -> new RuntimeException("Service not found."));
 
-  @Override
-  public ServiceDTO updateService(String id, ServiceDTO serviceDTO) {
-    return null;
-  }
+        com.sarapis.orservice.entity.core.Service updatedService = this.serviceRepository.save(service);
+        return this.getServiceById(updatedService.getId());
+    }
 
-  @Override
-  public void deleteService(String id) {
+    @Override
+    public void deleteService(String serviceId) {
+        com.sarapis.orservice.entity.core.Service service = this.serviceRepository.findById(serviceId)
+                .orElseThrow(() -> new RuntimeException("Service not found."));
+        this.attributeService.deleteRelatedAttributes(service.getId());
+        this.metadataService.deleteRelatedMetadata(service.getId());
+        this.serviceRepository.delete(service);
+    }
 
-  }
+    private void addRelatedData(ServiceDTO serviceDTO) {
+        serviceDTO.getAttributes().addAll(this.attributeService.getRelatedAttributes(serviceDTO.getId()));
+        serviceDTO.getMetadata().addAll(this.metadataService.getRelatedMetadata(serviceDTO.getId()));
+    }
 }

--- a/src/main/java/com/sarapis/orservice/service/TaxonomyService.java
+++ b/src/main/java/com/sarapis/orservice/service/TaxonomyService.java
@@ -4,13 +4,13 @@ import com.sarapis.orservice.dto.TaxonomyDTO;
 import java.util.List;
 
 public interface TaxonomyService {
-  List<TaxonomyDTO> getAllTaxonomies();
+    List<TaxonomyDTO> getAllTaxonomies();
 
-  TaxonomyDTO getTaxonomyById(String id);
+    TaxonomyDTO getTaxonomyById(String taxonomyId);
 
-  TaxonomyDTO createTaxonomy(TaxonomyDTO taxonomyDTO);
+    TaxonomyDTO createTaxonomy(TaxonomyDTO taxonomyDTO);
 
-  TaxonomyDTO updateTaxonomy(String id, TaxonomyDTO taxonomyDTO);
+    TaxonomyDTO updateTaxonomy(String taxonomyId, TaxonomyDTO taxonomyDTO);
 
-  void deleteTaxonomy(String id);
+    void deleteTaxonomy(String taxonomyId);
 }

--- a/src/main/java/com/sarapis/orservice/service/TaxonomyServiceImpl.java
+++ b/src/main/java/com/sarapis/orservice/service/TaxonomyServiceImpl.java
@@ -3,49 +3,71 @@ package com.sarapis.orservice.service;
 import com.sarapis.orservice.dto.TaxonomyDTO;
 import com.sarapis.orservice.entity.Taxonomy;
 import com.sarapis.orservice.repository.TaxonomyRepository;
-import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Service
 public class TaxonomyServiceImpl implements TaxonomyService {
-  private final TaxonomyRepository taxonomyRepository;
+    private final TaxonomyRepository taxonomyRepository;
+    private final MetadataService metadataService;
 
-  @Autowired
-  public TaxonomyServiceImpl(TaxonomyRepository taxonomyRepository) {
-    this.taxonomyRepository = taxonomyRepository;
-  }
+    @Autowired
+    public TaxonomyServiceImpl(TaxonomyRepository taxonomyRepository, MetadataService metadataService) {
+        this.taxonomyRepository = taxonomyRepository;
+        this.metadataService = metadataService;
+    }
 
-  private TaxonomyDTO mapToDTO(Taxonomy taxonomy) {
-    return null;
-  }
+    @Override
+    public List<TaxonomyDTO> getAllTaxonomies() {
+        List<TaxonomyDTO> taxonomyDTOs = this.taxonomyRepository.findAll()
+                .stream().map(Taxonomy::toDTO).toList();
+        taxonomyDTOs.forEach(this::addRelatedData);
+        return taxonomyDTOs;
+    }
 
-  private Taxonomy mapToEntity(TaxonomyDTO taxonomyDTO) {
-    return null;
-  }
+    @Override
+    public TaxonomyDTO getTaxonomyById(String taxonomyId) {
+        Taxonomy taxonomy = this.taxonomyRepository.findById(taxonomyId)
+                .orElseThrow(() -> new RuntimeException("Taxonomy not found."));
+        TaxonomyDTO taxonomyDTO = taxonomy.toDTO();
+        this.addRelatedData(taxonomyDTO);
+        return taxonomyDTO;
+    }
 
-  @Override
-  public List<TaxonomyDTO> getAllTaxonomies() {
-    return List.of();
-  }
+    @Override
+    public TaxonomyDTO createTaxonomy(TaxonomyDTO taxonomyDTO) {
+        Taxonomy taxonomy = taxonomyDTO.toEntity();
+        taxonomyDTO.getMetadata().forEach(e -> this.metadataService.createMetadata(taxonomy.getId(), e));
 
-  @Override
-  public TaxonomyDTO getTaxonomyById(String id) {
-    return null;
-  }
+        Taxonomy createdTaxonomy = this.taxonomyRepository.save(taxonomy);
+        return this.getTaxonomyById(createdTaxonomy.getId());
+    }
 
-  @Override
-  public TaxonomyDTO createTaxonomy(TaxonomyDTO taxonomyDTO) {
-    return null;
-  }
+    @Override
+    public TaxonomyDTO updateTaxonomy(String taxonomyId, TaxonomyDTO taxonomyDTO) {
+        Taxonomy taxonomy = this.taxonomyRepository.findById(taxonomyId)
+                .orElseThrow(() -> new RuntimeException("Taxonomy not found."));
 
-  @Override
-  public TaxonomyDTO updateTaxonomy(String id, TaxonomyDTO taxonomyDTO) {
-    return null;
-  }
+        taxonomy.setName(taxonomyDTO.getName());
+        taxonomy.setDescription(taxonomyDTO.getDescription());
+        taxonomy.setUri(taxonomyDTO.getUri());
+        taxonomy.setVersion(taxonomyDTO.getVersion());
 
-  @Override
-  public void deleteTaxonomy(String id) {
+        Taxonomy updatedTaxonomy = this.taxonomyRepository.save(taxonomy);
+        return this.getTaxonomyById(updatedTaxonomy.getId());
+    }
 
-  }
+    @Override
+    public void deleteTaxonomy(String taxonomyId) {
+        Taxonomy taxonomy = this.taxonomyRepository.findById(taxonomyId)
+                .orElseThrow(() -> new RuntimeException("Taxonomy not found."));
+        this.metadataService.deleteRelatedMetadata(taxonomy.getId());
+        this.taxonomyRepository.delete(taxonomy);
+    }
+
+    private void addRelatedData(TaxonomyDTO taxonomyDTO) {
+        taxonomyDTO.getMetadata().addAll(this.metadataService.getRelatedMetadata(taxonomyDTO.getId()));
+    }
 }

--- a/src/main/java/com/sarapis/orservice/service/TaxonomyTermService.java
+++ b/src/main/java/com/sarapis/orservice/service/TaxonomyTermService.java
@@ -4,13 +4,13 @@ import com.sarapis.orservice.dto.TaxonomyTermDTO;
 import java.util.List;
 
 public interface TaxonomyTermService {
-  List<TaxonomyTermDTO> getAllTaxonomyTerms();
+    List<TaxonomyTermDTO> getAllTaxonomyTerms();
 
-  TaxonomyTermDTO getTaxonomyTermById(String id);
+    TaxonomyTermDTO getTaxonomyTermById(String taxonomyTermId);
 
-  TaxonomyTermDTO createTaxonomyTerm(TaxonomyTermDTO taxonomyTermDTO);
+    TaxonomyTermDTO createTaxonomyTerm(TaxonomyTermDTO taxonomyTermDTO);
 
-  TaxonomyTermDTO updateTaxonomyTerm(String id, TaxonomyTermDTO taxonomyTermDTO);
+    TaxonomyTermDTO updateTaxonomyTerm(String taxonomyTermId, TaxonomyTermDTO taxonomyTermDTO);
 
-  void deleteTaxonomyTerm(String id);
+    void deleteTaxonomyTerm(String taxonomyTermId);
 }

--- a/src/main/java/com/sarapis/orservice/service/TaxonomyTermServiceImpl.java
+++ b/src/main/java/com/sarapis/orservice/service/TaxonomyTermServiceImpl.java
@@ -39,7 +39,14 @@ public class TaxonomyTermServiceImpl implements TaxonomyTermService {
 
     @Override
     public TaxonomyTermDTO createTaxonomyTerm(TaxonomyTermDTO taxonomyTermDTO) {
-        TaxonomyTerm taxonomyTerm = taxonomyTermDTO.toEntity(null);
+        TaxonomyTerm parent = null;
+
+        if (taxonomyTermDTO.getParentId() != null) {
+            parent = this.taxonomyTermRepository.findById(taxonomyTermDTO.getParentId())
+                    .orElseThrow(() -> new RuntimeException("Taxonomy term not found."));
+        }
+
+        TaxonomyTerm taxonomyTerm = taxonomyTermDTO.toEntity(parent);
         taxonomyTermDTO.getMetadata().forEach(e -> this.metadataService.createMetadata(taxonomyTerm.getId(), e));
 
         TaxonomyTerm createdTaxonomyTerm = this.taxonomyTermRepository.save(taxonomyTerm);

--- a/src/main/java/com/sarapis/orservice/service/TaxonomyTermServiceImpl.java
+++ b/src/main/java/com/sarapis/orservice/service/TaxonomyTermServiceImpl.java
@@ -1,52 +1,76 @@
 package com.sarapis.orservice.service;
 
 import com.sarapis.orservice.dto.TaxonomyTermDTO;
-import com.sarapis.orservice.entity.Taxonomy;
 import com.sarapis.orservice.entity.TaxonomyTerm;
 import com.sarapis.orservice.repository.TaxonomyTermRepository;
 import java.util.List;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 @Service
 public class TaxonomyTermServiceImpl implements TaxonomyTermService {
-  private final TaxonomyTermRepository taxonomyTermRepository;
+    private final TaxonomyTermRepository taxonomyTermRepository;
+    private final MetadataService metadataService;
 
-  @Autowired
-  public TaxonomyTermServiceImpl(TaxonomyTermRepository taxonomyTermRepository) {
-    this.taxonomyTermRepository = taxonomyTermRepository;
-  }
+    @Autowired
+    public TaxonomyTermServiceImpl(TaxonomyTermRepository taxonomyTermRepository, MetadataService metadataService) {
+        this.taxonomyTermRepository = taxonomyTermRepository;
+        this.metadataService = metadataService;
 
-  private TaxonomyTermServiceImpl mapToDTO(TaxonomyTerm taxonomyTerm) {
-    return null;
-  }
+    }
 
-  private Taxonomy mapToEntity(TaxonomyTermDTO taxonomyTermDTO) {
-    return null;
-  }
+    @Override
+    public List<TaxonomyTermDTO> getAllTaxonomyTerms() {
+        List<TaxonomyTermDTO> taxonomyTermDTOs = this.taxonomyTermRepository.findAll()
+                .stream().map(TaxonomyTerm::toDTO).toList();
+        taxonomyTermDTOs.forEach(this::addRelatedData);
+        return taxonomyTermDTOs;
+    }
 
-  @Override
-  public List<TaxonomyTermDTO> getAllTaxonomyTerms() {
-    return List.of();
-  }
+    @Override
+    public TaxonomyTermDTO getTaxonomyTermById(String taxonomyTermId) {
+        TaxonomyTerm taxonomyTerm = this.taxonomyTermRepository.findById(taxonomyTermId)
+                .orElseThrow(() -> new RuntimeException("Taxonomy term not found."));
+        TaxonomyTermDTO taxonomyTermDTO = taxonomyTerm.toDTO();
+        this.addRelatedData(taxonomyTermDTO);
+        return taxonomyTermDTO;
+    }
 
-  @Override
-  public TaxonomyTermDTO getTaxonomyTermById(String id) {
-    return null;
-  }
+    @Override
+    public TaxonomyTermDTO createTaxonomyTerm(TaxonomyTermDTO taxonomyTermDTO) {
+        TaxonomyTerm taxonomyTerm = taxonomyTermDTO.toEntity(null);
+        taxonomyTermDTO.getMetadata().forEach(e -> this.metadataService.createMetadata(taxonomyTerm.getId(), e));
 
-  @Override
-  public TaxonomyTermDTO createTaxonomyTerm(TaxonomyTermDTO taxonomyTermDTO) {
-    return null;
-  }
+        TaxonomyTerm createdTaxonomyTerm = this.taxonomyTermRepository.save(taxonomyTerm);
+        return this.getTaxonomyTermById(createdTaxonomyTerm.getId());
+    }
 
-  @Override
-  public TaxonomyTermDTO updateTaxonomyTerm(String id, TaxonomyTermDTO taxonomyTermDTO) {
-    return null;
-  }
+    @Override
+    public TaxonomyTermDTO updateTaxonomyTerm(String taxonomyTermId, TaxonomyTermDTO taxonomyTermDTO) {
+        TaxonomyTerm taxonomyTerm = this.taxonomyTermRepository.findById(taxonomyTermId)
+                .orElseThrow(() -> new RuntimeException("Taxonomy term not found."));
 
-  @Override
-  public void deleteTaxonomyTerm(String id) {
+        taxonomyTerm.setCode(taxonomyTermDTO.getCode());
+        taxonomyTerm.setName(taxonomyTermDTO.getName());
+        taxonomyTerm.setDescription(taxonomyTermDTO.getDescription());
+        taxonomyTerm.setTaxonomy(taxonomyTermDTO.getTaxonomy());
+        taxonomyTerm.setLanguage(taxonomyTermDTO.getLanguage());
+        taxonomyTerm.setTermUri(taxonomyTermDTO.getTermUri());
 
-  }
+        TaxonomyTerm updatedTaxonomyTerm = this.taxonomyTermRepository.save(taxonomyTerm);
+        return this.getTaxonomyTermById(updatedTaxonomyTerm.getId());
+    }
+
+    @Override
+    public void deleteTaxonomyTerm(String taxonomyTermId) {
+        TaxonomyTerm taxonomyTerm = this.taxonomyTermRepository.findById(taxonomyTermId)
+                .orElseThrow(() -> new RuntimeException("Taxonomy term not found."));
+        this.metadataService.deleteRelatedMetadata(taxonomyTerm.getId());
+        this.taxonomyTermRepository.delete(taxonomyTerm);
+    }
+
+    private void addRelatedData(TaxonomyTermDTO taxonomyTermDTO) {
+        taxonomyTermDTO.getMetadata().addAll(this.metadataService.getRelatedMetadata(taxonomyTermDTO.getId()));
+    }
 }


### PR DESCRIPTION
I noticed that `init.sql` file in their Github was updated to v3.1 so I also updated our codebase to accomodate that. 

Main Changes
- Made most of the relations bidirectional so inserting is easier.
- Changed toEntity methods because of the directional relation.  
- Refactored attribute and metadata to their own separate service. Other entity services now calls those two services instead.
- I also finished implemented Location, Taxonomy, and TaxonomyTerm routes.

Insertion and deletion should work all the entities here. As for updating, so far I've only implemented it for non-relation attributes.