### PR TITLE
Feat/pagination

### DIFF
--- a/src/main/java/com/sarapis/orservice/controller/AccessibilityController.java
+++ b/src/main/java/com/sarapis/orservice/controller/AccessibilityController.java
@@ -24,12 +24,17 @@ public class AccessibilityController {
     public ResponseEntity<PaginationDTO<AccessibilityDTO>> getAllAccessibilities(@RequestParam(defaultValue = "1") Integer page,
                                                                                  @RequestParam(defaultValue = "10") Integer perPage) {
         List<AccessibilityDTO> accessibilityDTOs = this.accessibilityService.getAllAccessibilities();
-        PaginationDTO<AccessibilityDTO> paginationDTO = PaginationDTO.of(
-            accessibilityDTOs,
-            page,
-            perPage
-        );
-        return ResponseEntity.ok(paginationDTO);
+
+        try {
+            PaginationDTO<AccessibilityDTO> paginationDTO = PaginationDTO.of(
+                    accessibilityDTOs,
+                    page,
+                    perPage
+            );
+            return ResponseEntity.ok(paginationDTO);
+        } catch (RuntimeException e) {
+            return ResponseEntity.badRequest().build();
+        }
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/com/sarapis/orservice/controller/AccessibilityController.java
+++ b/src/main/java/com/sarapis/orservice/controller/AccessibilityController.java
@@ -20,8 +20,8 @@ public class AccessibilityController {
     }
 
     @GetMapping
-    public ResponseEntity<PaginationDTO<AccessibilityDTO>> getAllAccessibilities(@RequestParam(defaultValue = "1") Integer page,
-                                                                                 @RequestParam(defaultValue = "10") Integer perPage) {
+    public ResponseEntity<PaginationDTO<AccessibilityDTO>> getAllAccessibilities(@RequestParam(name = "page", defaultValue = "1") int page,
+                                                                                 @RequestParam(name = "perPage", defaultValue = "10") int perPage) {
         List<AccessibilityDTO> accessibilityDTOs = this.accessibilityService.getAllAccessibilities();
 
         try {

--- a/src/main/java/com/sarapis/orservice/controller/AccessibilityController.java
+++ b/src/main/java/com/sarapis/orservice/controller/AccessibilityController.java
@@ -1,6 +1,7 @@
 package com.sarapis.orservice.controller;
 
 import com.sarapis.orservice.dto.AccessibilityDTO;
+import com.sarapis.orservice.dto.PaginationDTO;
 import com.sarapis.orservice.service.AccessibilityService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -20,9 +21,15 @@ public class AccessibilityController {
     }
 
     @GetMapping
-    public ResponseEntity<List<AccessibilityDTO>> getAllAccessibilities() {
+    public ResponseEntity<PaginationDTO<AccessibilityDTO>> getAllAccessibilities(@RequestParam(defaultValue = "1") Integer page,
+                                                                                 @RequestParam(defaultValue = "10") Integer perPage) {
         List<AccessibilityDTO> accessibilityDTOs = this.accessibilityService.getAllAccessibilities();
-        return ResponseEntity.ok(accessibilityDTOs);
+        PaginationDTO<AccessibilityDTO> paginationDTO = PaginationDTO.of(
+            accessibilityDTOs,
+            page,
+            perPage
+        );
+        return ResponseEntity.ok(paginationDTO);
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/com/sarapis/orservice/controller/AccessibilityController.java
+++ b/src/main/java/com/sarapis/orservice/controller/AccessibilityController.java
@@ -2,6 +2,7 @@ package com.sarapis.orservice.controller;
 
 import com.sarapis.orservice.dto.AccessibilityDTO;
 import com.sarapis.orservice.dto.PaginationDTO;
+import com.sarapis.orservice.exception.InvalidInputException;
 import com.sarapis.orservice.service.AccessibilityService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -24,16 +25,15 @@ public class AccessibilityController {
                                                                                  @RequestParam(name = "perPage", defaultValue = "10") int perPage) {
         List<AccessibilityDTO> accessibilityDTOs = this.accessibilityService.getAllAccessibilities();
 
-        try {
-            PaginationDTO<AccessibilityDTO> paginationDTO = PaginationDTO.of(
-                    accessibilityDTOs,
-                    page,
-                    perPage
-            );
-            return ResponseEntity.ok(paginationDTO);
-        } catch (RuntimeException e) {
-            return ResponseEntity.badRequest().build();
-        }
+        if(page <= 0) throw new InvalidInputException("Invalid value provided for 'page'.");
+        if(perPage <= 0) throw new InvalidInputException("Invalid value provided for 'perPage'.");
+        
+        PaginationDTO<AccessibilityDTO> paginationDTO = PaginationDTO.of(
+            accessibilityDTOs,
+            page,
+            perPage
+        );
+        return ResponseEntity.ok(paginationDTO);
     }
 
     @GetMapping("/{accessibilityId}")

--- a/src/main/java/com/sarapis/orservice/controller/AddressController.java
+++ b/src/main/java/com/sarapis/orservice/controller/AddressController.java
@@ -20,8 +20,8 @@ public class AddressController {
     }
 
     @GetMapping
-    public ResponseEntity<PaginationDTO<AddressDTO>> getAllAddresses(@RequestParam(defaultValue = "1") Integer page,
-                                                                     @RequestParam(defaultValue = "10") Integer perPage) {
+    public ResponseEntity<PaginationDTO<AddressDTO>> getAllAddresses(@RequestParam(name = "page", defaultValue = "1") int page,
+                                                                     @RequestParam(name = "perPage", defaultValue = "10") int perPage) {
         List<AddressDTO> addressDTOs = this.addressService.getAllAddresses();
 
         try {

--- a/src/main/java/com/sarapis/orservice/controller/AddressController.java
+++ b/src/main/java/com/sarapis/orservice/controller/AddressController.java
@@ -1,6 +1,7 @@
 package com.sarapis.orservice.controller;
 
 import com.sarapis.orservice.dto.AddressDTO;
+import com.sarapis.orservice.dto.PaginationDTO;
 import com.sarapis.orservice.service.AddressService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -19,9 +20,15 @@ public class AddressController {
     }
 
     @GetMapping
-    public ResponseEntity<List<AddressDTO>> getAllAddresses() {
+    public ResponseEntity<PaginationDTO<AddressDTO>> getAllAddresses(@RequestParam(defaultValue = "1") Integer page,
+                                                                     @RequestParam(defaultValue = "10") Integer perPage) {
         List<AddressDTO> addressDTOs = this.addressService.getAllAddresses();
-        return ResponseEntity.ok(addressDTOs);
+        PaginationDTO<AddressDTO> paginationDTO = PaginationDTO.of(
+            addressDTOs,
+            page,
+            perPage
+        );
+        return ResponseEntity.ok(paginationDTO);
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/com/sarapis/orservice/controller/AddressController.java
+++ b/src/main/java/com/sarapis/orservice/controller/AddressController.java
@@ -23,12 +23,17 @@ public class AddressController {
     public ResponseEntity<PaginationDTO<AddressDTO>> getAllAddresses(@RequestParam(defaultValue = "1") Integer page,
                                                                      @RequestParam(defaultValue = "10") Integer perPage) {
         List<AddressDTO> addressDTOs = this.addressService.getAllAddresses();
-        PaginationDTO<AddressDTO> paginationDTO = PaginationDTO.of(
-            addressDTOs,
-            page,
-            perPage
-        );
-        return ResponseEntity.ok(paginationDTO);
+
+        try {
+            PaginationDTO<AddressDTO> paginationDTO = PaginationDTO.of(
+                    addressDTOs,
+                    page,
+                    perPage
+            );
+            return ResponseEntity.ok(paginationDTO);
+        } catch (RuntimeException e) {
+            return ResponseEntity.badRequest().build();
+        }
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/com/sarapis/orservice/controller/AddressController.java
+++ b/src/main/java/com/sarapis/orservice/controller/AddressController.java
@@ -2,6 +2,7 @@ package com.sarapis.orservice.controller;
 
 import com.sarapis.orservice.dto.AddressDTO;
 import com.sarapis.orservice.dto.PaginationDTO;
+import com.sarapis.orservice.exception.InvalidInputException;
 import com.sarapis.orservice.service.AddressService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -24,16 +25,15 @@ public class AddressController {
                                                                      @RequestParam(name = "perPage", defaultValue = "10") int perPage) {
         List<AddressDTO> addressDTOs = this.addressService.getAllAddresses();
 
-        try {
-            PaginationDTO<AddressDTO> paginationDTO = PaginationDTO.of(
-                    addressDTOs,
-                    page,
-                    perPage
-            );
-            return ResponseEntity.ok(paginationDTO);
-        } catch (RuntimeException e) {
-            return ResponseEntity.badRequest().build();
-        }
+        if(page <= 0) throw new InvalidInputException("Invalid input provided for 'page'.");
+        if(perPage <= 0) throw new InvalidInputException("Invalid input provided for 'perPage'.");
+
+        PaginationDTO<AddressDTO> paginationDTO = PaginationDTO.of(
+            addressDTOs,
+            page,
+            perPage
+        );
+        return ResponseEntity.ok(paginationDTO);
     }
 
     @GetMapping("/{addressId}")

--- a/src/main/java/com/sarapis/orservice/controller/AttributeController.java
+++ b/src/main/java/com/sarapis/orservice/controller/AttributeController.java
@@ -1,6 +1,7 @@
 package com.sarapis.orservice.controller;
 
 import com.sarapis.orservice.dto.AttributeDTO;
+import com.sarapis.orservice.dto.PaginationDTO;
 import com.sarapis.orservice.service.AttributeService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -19,9 +20,15 @@ public class AttributeController {
     }
 
     @GetMapping
-    public ResponseEntity<List<AttributeDTO>> getAllAttributes() {
+    public ResponseEntity<PaginationDTO<AttributeDTO>> getAllAttributes(@RequestParam(defaultValue = "1") Integer page,
+                                                                        @RequestParam(defaultValue = "10") Integer perPage) {
         List<AttributeDTO> attributeDTOs = this.attributeService.getAllAttributes();
-        return ResponseEntity.ok(attributeDTOs);
+        PaginationDTO<AttributeDTO> paginationDTO = PaginationDTO.of(
+            attributeDTOs,
+            page,
+            perPage
+        );
+        return ResponseEntity.ok(paginationDTO);
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/com/sarapis/orservice/controller/AttributeController.java
+++ b/src/main/java/com/sarapis/orservice/controller/AttributeController.java
@@ -20,8 +20,8 @@ public class AttributeController {
     }
 
     @GetMapping
-    public ResponseEntity<PaginationDTO<AttributeDTO>> getAllAttributes(@RequestParam(defaultValue = "1") Integer page,
-                                                                        @RequestParam(defaultValue = "10") Integer perPage) {
+    public ResponseEntity<PaginationDTO<AttributeDTO>> getAllAttributes(@RequestParam(name = "page", defaultValue = "1") int page,
+                                                                        @RequestParam(name = "perPage", defaultValue = "10") int perPage) {
         List<AttributeDTO> attributeDTOs = this.attributeService.getAllAttributes();
 
         try {

--- a/src/main/java/com/sarapis/orservice/controller/AttributeController.java
+++ b/src/main/java/com/sarapis/orservice/controller/AttributeController.java
@@ -2,6 +2,7 @@ package com.sarapis.orservice.controller;
 
 import com.sarapis.orservice.dto.AttributeDTO;
 import com.sarapis.orservice.dto.PaginationDTO;
+import com.sarapis.orservice.exception.InvalidInputException;
 import com.sarapis.orservice.service.AttributeService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -24,16 +25,15 @@ public class AttributeController {
                                                                         @RequestParam(name = "perPage", defaultValue = "10") int perPage) {
         List<AttributeDTO> attributeDTOs = this.attributeService.getAllAttributes();
 
-        try {
-            PaginationDTO<AttributeDTO> paginationDTO = PaginationDTO.of(
-                    attributeDTOs,
-                    page,
-                    perPage
-            );
-            return ResponseEntity.ok(paginationDTO);
-        } catch (RuntimeException e) {
-            return ResponseEntity.badRequest().build();
-        }
+        if(page <= 0) throw new InvalidInputException("Invalid value provided for 'page'.");
+        if(perPage <= 0) throw new InvalidInputException("Invalid value provided for 'perPage'.");
+
+        PaginationDTO<AttributeDTO> paginationDTO = PaginationDTO.of(
+            attributeDTOs,
+            page,
+            perPage
+        );
+        return ResponseEntity.ok(paginationDTO);
     }
 
     @GetMapping("/{attributeId}")

--- a/src/main/java/com/sarapis/orservice/controller/AttributeController.java
+++ b/src/main/java/com/sarapis/orservice/controller/AttributeController.java
@@ -23,12 +23,17 @@ public class AttributeController {
     public ResponseEntity<PaginationDTO<AttributeDTO>> getAllAttributes(@RequestParam(defaultValue = "1") Integer page,
                                                                         @RequestParam(defaultValue = "10") Integer perPage) {
         List<AttributeDTO> attributeDTOs = this.attributeService.getAllAttributes();
-        PaginationDTO<AttributeDTO> paginationDTO = PaginationDTO.of(
-            attributeDTOs,
-            page,
-            perPage
-        );
-        return ResponseEntity.ok(paginationDTO);
+
+        try {
+            PaginationDTO<AttributeDTO> paginationDTO = PaginationDTO.of(
+                    attributeDTOs,
+                    page,
+                    perPage
+            );
+            return ResponseEntity.ok(paginationDTO);
+        } catch (RuntimeException e) {
+            return ResponseEntity.badRequest().build();
+        }
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/com/sarapis/orservice/controller/ContactController.java
+++ b/src/main/java/com/sarapis/orservice/controller/ContactController.java
@@ -1,6 +1,7 @@
 package com.sarapis.orservice.controller;
 
 import com.sarapis.orservice.dto.ContactDTO;
+import com.sarapis.orservice.dto.PaginationDTO;
 import com.sarapis.orservice.service.ContactService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -20,9 +21,15 @@ public class ContactController {
     }
 
     @GetMapping
-    public ResponseEntity<List<ContactDTO>> getAllContacts() {
+    public ResponseEntity<PaginationDTO<ContactDTO>> getAllContacts(@RequestParam(defaultValue = "1") Integer page,
+                                                                    @RequestParam(defaultValue = "10") Integer perPage) {
         List<ContactDTO> contactDTOs = this.contactService.getAllContacts();
-        return ResponseEntity.ok(contactDTOs);
+        PaginationDTO<ContactDTO> paginationDTO = PaginationDTO.of(
+            contactDTOs,
+            page,
+            perPage
+        );
+        return ResponseEntity.ok(paginationDTO);
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/com/sarapis/orservice/controller/ContactController.java
+++ b/src/main/java/com/sarapis/orservice/controller/ContactController.java
@@ -24,12 +24,17 @@ public class ContactController {
     public ResponseEntity<PaginationDTO<ContactDTO>> getAllContacts(@RequestParam(defaultValue = "1") Integer page,
                                                                     @RequestParam(defaultValue = "10") Integer perPage) {
         List<ContactDTO> contactDTOs = this.contactService.getAllContacts();
-        PaginationDTO<ContactDTO> paginationDTO = PaginationDTO.of(
-            contactDTOs,
-            page,
-            perPage
-        );
-        return ResponseEntity.ok(paginationDTO);
+
+        try {
+            PaginationDTO<ContactDTO> paginationDTO = PaginationDTO.of(
+                contactDTOs,
+                page,
+                perPage
+            );
+            return ResponseEntity.ok(paginationDTO);
+        } catch (RuntimeException e) {
+            return ResponseEntity.badRequest().build();
+        }
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/com/sarapis/orservice/controller/ContactController.java
+++ b/src/main/java/com/sarapis/orservice/controller/ContactController.java
@@ -3,6 +3,7 @@ package com.sarapis.orservice.controller;
 import com.sarapis.orservice.dto.ContactDTO;
 import com.sarapis.orservice.dto.PaginationDTO;
 import com.sarapis.orservice.dto.upsert.UpsertContactDTO;
+import com.sarapis.orservice.exception.InvalidInputException;
 import com.sarapis.orservice.service.ContactService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -25,16 +26,15 @@ public class ContactController {
                                                                     @RequestParam(defaultValue = "10") Integer perPage) {
         List<ContactDTO> contactDTOs = this.contactService.getAllContacts();
 
-        try {
-            PaginationDTO<ContactDTO> paginationDTO = PaginationDTO.of(
-                contactDTOs,
-                page,
-                perPage
-            );
-            return ResponseEntity.ok(paginationDTO);
-        } catch (RuntimeException e) {
-            return ResponseEntity.badRequest().build();
-        }
+        if(page <= 0) throw new InvalidInputException("Invalid value provided for 'page'.");
+        if(perPage <= 0) throw new InvalidInputException("Invalid value provided for 'perPage'.");
+
+        PaginationDTO<ContactDTO> paginationDTO = PaginationDTO.of(
+            contactDTOs,
+            page,
+            perPage
+        );
+        return ResponseEntity.ok(paginationDTO);
     }
 
     @GetMapping("/{contactId}")

--- a/src/main/java/com/sarapis/orservice/controller/LanguageController.java
+++ b/src/main/java/com/sarapis/orservice/controller/LanguageController.java
@@ -23,12 +23,17 @@ public class LanguageController {
     public ResponseEntity<PaginationDTO<LanguageDTO>> getAllLanguages(@RequestParam(defaultValue = "1") Integer page,
                                                                       @RequestParam(defaultValue = "10") Integer perPage) {
         List<LanguageDTO> languageDTOs = this.languageService.getAllLanguages();
-        PaginationDTO<LanguageDTO> paginationDTO = PaginationDTO.of(
-            languageDTOs,
-            page,
-            perPage
-        );
-        return ResponseEntity.ok(paginationDTO);
+
+        try {
+            PaginationDTO<LanguageDTO> paginationDTO = PaginationDTO.of(
+                    languageDTOs,
+                    page,
+                    perPage
+            );
+            return ResponseEntity.ok(paginationDTO);
+        } catch (RuntimeException e) {
+            return ResponseEntity.badRequest().build();
+        }
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/com/sarapis/orservice/controller/LanguageController.java
+++ b/src/main/java/com/sarapis/orservice/controller/LanguageController.java
@@ -2,6 +2,7 @@ package com.sarapis.orservice.controller;
 
 import com.sarapis.orservice.dto.LanguageDTO;
 import com.sarapis.orservice.dto.PaginationDTO;
+import com.sarapis.orservice.exception.InvalidInputException;
 import com.sarapis.orservice.service.LanguageService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -24,16 +25,15 @@ public class LanguageController {
                                                                       @RequestParam(name = "perPage", defaultValue = "10") int perPage) {
         List<LanguageDTO> languageDTOs = this.languageService.getAllLanguages();
 
-        try {
-            PaginationDTO<LanguageDTO> paginationDTO = PaginationDTO.of(
-                    languageDTOs,
-                    page,
-                    perPage
-            );
-            return ResponseEntity.ok(paginationDTO);
-        } catch (RuntimeException e) {
-            return ResponseEntity.badRequest().build();
-        }
+        if(page <= 0) throw new InvalidInputException("Invalid input provided for 'page'.");
+        if(perPage <= 0) throw new InvalidInputException("Invalid input provided for 'perPage'.");
+
+        PaginationDTO<LanguageDTO> paginationDTO = PaginationDTO.of(
+                languageDTOs,
+                page,
+                perPage
+        );
+        return ResponseEntity.ok(paginationDTO);
     }
 
     @GetMapping("/{languageId}")

--- a/src/main/java/com/sarapis/orservice/controller/LanguageController.java
+++ b/src/main/java/com/sarapis/orservice/controller/LanguageController.java
@@ -20,8 +20,8 @@ public class LanguageController {
     }
 
     @GetMapping
-    public ResponseEntity<PaginationDTO<LanguageDTO>> getAllLanguages(@RequestParam(defaultValue = "1") Integer page,
-                                                                      @RequestParam(defaultValue = "10") Integer perPage) {
+    public ResponseEntity<PaginationDTO<LanguageDTO>> getAllLanguages(@RequestParam(name = "page", defaultValue = "1") int page,
+                                                                      @RequestParam(name = "perPage", defaultValue = "10") int perPage) {
         List<LanguageDTO> languageDTOs = this.languageService.getAllLanguages();
 
         try {

--- a/src/main/java/com/sarapis/orservice/controller/LanguageController.java
+++ b/src/main/java/com/sarapis/orservice/controller/LanguageController.java
@@ -1,6 +1,7 @@
 package com.sarapis.orservice.controller;
 
 import com.sarapis.orservice.dto.LanguageDTO;
+import com.sarapis.orservice.dto.PaginationDTO;
 import com.sarapis.orservice.service.LanguageService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -19,9 +20,15 @@ public class LanguageController {
     }
 
     @GetMapping
-    public ResponseEntity<List<LanguageDTO>> getAllLanguages() {
+    public ResponseEntity<PaginationDTO<LanguageDTO>> getAllLanguages(@RequestParam(defaultValue = "1") Integer page,
+                                                                      @RequestParam(defaultValue = "10") Integer perPage) {
         List<LanguageDTO> languageDTOs = this.languageService.getAllLanguages();
-        return ResponseEntity.ok(languageDTOs);
+        PaginationDTO<LanguageDTO> paginationDTO = PaginationDTO.of(
+            languageDTOs,
+            page,
+            perPage
+        );
+        return ResponseEntity.ok(paginationDTO);
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/com/sarapis/orservice/controller/LocationController.java
+++ b/src/main/java/com/sarapis/orservice/controller/LocationController.java
@@ -21,8 +21,8 @@ public class LocationController {
     }
 
     @GetMapping
-    public ResponseEntity<PaginationDTO<LocationDTO>> getAllLocations(@RequestParam(defaultValue = "1") Integer page,
-                                                                      @RequestParam(defaultValue = "10") Integer perPage) {
+    public ResponseEntity<PaginationDTO<LocationDTO>> getAllLocations(@RequestParam(name = "page", defaultValue = "1") int page,
+                                                                      @RequestParam(name = "perPage", defaultValue = "10") int perPage) {
         List<LocationDTO> locations = this.locationService.getAllLocations();
 
         try {

--- a/src/main/java/com/sarapis/orservice/controller/LocationController.java
+++ b/src/main/java/com/sarapis/orservice/controller/LocationController.java
@@ -3,6 +3,7 @@ package com.sarapis.orservice.controller;
 import com.sarapis.orservice.dto.LocationDTO;
 import com.sarapis.orservice.dto.PaginationDTO;
 import com.sarapis.orservice.dto.upsert.UpsertLocationDTO;
+import com.sarapis.orservice.exception.InvalidInputException;
 import com.sarapis.orservice.service.LocationService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -25,16 +26,15 @@ public class LocationController {
                                                                       @RequestParam(name = "perPage", defaultValue = "10") int perPage) {
         List<LocationDTO> locations = this.locationService.getAllLocations();
 
-        try {
-            PaginationDTO<LocationDTO> pagination = PaginationDTO.of(
-                    locations,
-                    page,
-                    perPage
-            );
-            return ResponseEntity.ok(pagination);
-        } catch (RuntimeException e) {
-            return ResponseEntity.badRequest().build();
-        }
+        if(page <= 0) throw new InvalidInputException("Invalid input provided for 'page'.");
+        if(perPage <= 0) throw new InvalidInputException("Invalid input provided for 'perPage'.");
+
+        PaginationDTO<LocationDTO> pagination = PaginationDTO.of(
+            locations,
+            page,
+            perPage
+        );
+        return ResponseEntity.ok(pagination);
     }
 
     @GetMapping("/{locationId}")

--- a/src/main/java/com/sarapis/orservice/controller/LocationController.java
+++ b/src/main/java/com/sarapis/orservice/controller/LocationController.java
@@ -20,19 +20,20 @@ public class LocationController {
     }
 
     @GetMapping
-    public ResponseEntity<PaginationDTO<LocationDTO>> getAllLocations() {
+    public ResponseEntity<PaginationDTO<LocationDTO>> getAllLocations(@RequestParam(defaultValue = "1") Integer page,
+                                                                      @RequestParam(defaultValue = "10") Integer perPage) {
         List<LocationDTO> locations = this.locationService.getAllLocations();
-        PaginationDTO<LocationDTO> pagination = PaginationDTO.of(
-                locations.size(),
-                1,
-                1,
-                locations.size(),
-                true,
-                false,
-                false,
-                locations
-        );
-        return ResponseEntity.ok(pagination);
+
+        try {
+            PaginationDTO<LocationDTO> pagination = PaginationDTO.of(
+                    locations,
+                    page,
+                    perPage
+            );
+            return ResponseEntity.ok(pagination);
+        } catch (RuntimeException e) {
+            return ResponseEntity.badRequest().build();
+        }
     }
 
     @GetMapping("/{locationId}")

--- a/src/main/java/com/sarapis/orservice/controller/OrganizationController.java
+++ b/src/main/java/com/sarapis/orservice/controller/OrganizationController.java
@@ -3,6 +3,7 @@ package com.sarapis.orservice.controller;
 import com.sarapis.orservice.dto.OrganizationDTO;
 import com.sarapis.orservice.dto.PaginationDTO;
 import com.sarapis.orservice.dto.upsert.UpsertOrganizationDTO;
+import com.sarapis.orservice.exception.InvalidInputException;
 import com.sarapis.orservice.service.OrganizationService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -26,16 +27,15 @@ public class OrganizationController {
     {
         List<OrganizationDTO> organizations = organizationService.getAllOrganizations();
 
-        try {
-            PaginationDTO<OrganizationDTO> paginationDTO = PaginationDTO.of(
-                    organizations,
-                    page,
-                    perPage
-            );
-            return ResponseEntity.ok(paginationDTO);
-        } catch (RuntimeException e) {
-            return ResponseEntity.badRequest().build();
-        }
+        if(page <= 0) throw new InvalidInputException("Invalid input provided for 'page'.");
+        if(perPage <= 0) throw new InvalidInputException("Invalid input provided for 'perPage'.");
+
+        PaginationDTO<OrganizationDTO> paginationDTO = PaginationDTO.of(
+            organizations,
+            page,
+            perPage
+        );
+        return ResponseEntity.ok(paginationDTO);
     }
 
     @GetMapping("/{organizationId}")

--- a/src/main/java/com/sarapis/orservice/controller/OrganizationController.java
+++ b/src/main/java/com/sarapis/orservice/controller/OrganizationController.java
@@ -21,8 +21,8 @@ public class OrganizationController {
     }
 
     @GetMapping
-    public ResponseEntity<PaginationDTO<OrganizationDTO>> getAllOrganizations(@RequestParam(defaultValue = "1") Integer page,
-                                                                              @RequestParam(defaultValue = "10") Integer perPage)
+    public ResponseEntity<PaginationDTO<OrganizationDTO>> getAllOrganizations(@RequestParam(name = "page", defaultValue = "1") int page,
+                                                                              @RequestParam(name = "perPage", defaultValue = "10") int perPage)
     {
         List<OrganizationDTO> organizations = organizationService.getAllOrganizations();
 

--- a/src/main/java/com/sarapis/orservice/controller/OrganizationController.java
+++ b/src/main/java/com/sarapis/orservice/controller/OrganizationController.java
@@ -25,12 +25,17 @@ public class OrganizationController {
                                                                               @RequestParam(defaultValue = "10") Integer perPage)
     {
         List<OrganizationDTO> organizations = organizationService.getAllOrganizations();
-        PaginationDTO<OrganizationDTO> paginationDTO = PaginationDTO.of(
-                organizations,
-                page,
-                perPage
-        );
-        return ResponseEntity.ok(paginationDTO);
+
+        try {
+            PaginationDTO<OrganizationDTO> paginationDTO = PaginationDTO.of(
+                    organizations,
+                    page,
+                    perPage
+            );
+            return ResponseEntity.ok(paginationDTO);
+        } catch (RuntimeException e) {
+            return ResponseEntity.badRequest().build();
+        }
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/com/sarapis/orservice/controller/OrganizationController.java
+++ b/src/main/java/com/sarapis/orservice/controller/OrganizationController.java
@@ -21,17 +21,14 @@ public class OrganizationController {
     }
 
     @GetMapping
-    public ResponseEntity<PaginationDTO<OrganizationDTO>> getAllOrganizations() {
+    public ResponseEntity<PaginationDTO<OrganizationDTO>> getAllOrganizations(@RequestParam(defaultValue = "1") Integer page,
+                                                                              @RequestParam(defaultValue = "10") Integer perPage)
+    {
         List<OrganizationDTO> organizations = organizationService.getAllOrganizations();
         PaginationDTO<OrganizationDTO> paginationDTO = PaginationDTO.of(
-                organizations.size(),
-                1,
-                1,
-                organizations.size(),
-                true,
-                false,
-                false,
-                organizations
+                organizations,
+                page,
+                perPage
         );
         return ResponseEntity.ok(paginationDTO);
     }

--- a/src/main/java/com/sarapis/orservice/controller/PhoneController.java
+++ b/src/main/java/com/sarapis/orservice/controller/PhoneController.java
@@ -20,8 +20,8 @@ public class PhoneController {
     }
 
     @GetMapping
-    public ResponseEntity<PaginationDTO<PhoneDTO>> getAllPhones(@RequestParam(defaultValue = "1") Integer page,
-                                                                @RequestParam(defaultValue = "10") Integer perPage) {
+    public ResponseEntity<PaginationDTO<PhoneDTO>> getAllPhones(@RequestParam(name = "page", defaultValue = "1") int page,
+                                                                @RequestParam(name = "perPage", defaultValue = "10") int perPage) {
         List<PhoneDTO> phoneDTOs = this.phoneService.getAllPhones();
 
         try {

--- a/src/main/java/com/sarapis/orservice/controller/PhoneController.java
+++ b/src/main/java/com/sarapis/orservice/controller/PhoneController.java
@@ -1,5 +1,6 @@
 package com.sarapis.orservice.controller;
 
+import com.sarapis.orservice.dto.PaginationDTO;
 import com.sarapis.orservice.dto.PhoneDTO;
 import com.sarapis.orservice.service.PhoneService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,9 +21,15 @@ public class PhoneController {
     }
 
     @GetMapping
-    public ResponseEntity<List<PhoneDTO>> getAllPhones() {
+    public ResponseEntity<PaginationDTO<PhoneDTO>> getAllPhones(@RequestParam(defaultValue = "1") Integer page,
+                                                                @RequestParam(defaultValue = "10") Integer perPage) {
         List<PhoneDTO> phoneDTOs = this.phoneService.getAllPhones();
-        return ResponseEntity.ok(phoneDTOs);
+        PaginationDTO<PhoneDTO> paginationDTO = PaginationDTO.of(
+            phoneDTOs,
+            page,
+            perPage
+        );
+        return ResponseEntity.ok(paginationDTO);
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/com/sarapis/orservice/controller/PhoneController.java
+++ b/src/main/java/com/sarapis/orservice/controller/PhoneController.java
@@ -24,12 +24,17 @@ public class PhoneController {
     public ResponseEntity<PaginationDTO<PhoneDTO>> getAllPhones(@RequestParam(defaultValue = "1") Integer page,
                                                                 @RequestParam(defaultValue = "10") Integer perPage) {
         List<PhoneDTO> phoneDTOs = this.phoneService.getAllPhones();
-        PaginationDTO<PhoneDTO> paginationDTO = PaginationDTO.of(
-            phoneDTOs,
-            page,
-            perPage
-        );
-        return ResponseEntity.ok(paginationDTO);
+
+        try {
+            PaginationDTO<PhoneDTO> paginationDTO = PaginationDTO.of(
+                    phoneDTOs,
+                    page,
+                    perPage
+            );
+            return ResponseEntity.ok(paginationDTO);
+        } catch (RuntimeException e) {
+            return  ResponseEntity.badRequest().build();
+        }
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/com/sarapis/orservice/controller/PhoneController.java
+++ b/src/main/java/com/sarapis/orservice/controller/PhoneController.java
@@ -2,6 +2,7 @@ package com.sarapis.orservice.controller;
 
 import com.sarapis.orservice.dto.PaginationDTO;
 import com.sarapis.orservice.dto.PhoneDTO;
+import com.sarapis.orservice.exception.InvalidInputException;
 import com.sarapis.orservice.service.PhoneService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -24,16 +25,15 @@ public class PhoneController {
                                                                 @RequestParam(name = "perPage", defaultValue = "10") int perPage) {
         List<PhoneDTO> phoneDTOs = this.phoneService.getAllPhones();
 
-        try {
-            PaginationDTO<PhoneDTO> paginationDTO = PaginationDTO.of(
-                    phoneDTOs,
-                    page,
-                    perPage
-            );
-            return ResponseEntity.ok(paginationDTO);
-        } catch (RuntimeException e) {
-            return  ResponseEntity.badRequest().build();
-        }
+        if(page <= 0) throw new InvalidInputException("Invalid input provided for 'page'.");
+        if(perPage <= 0) throw new InvalidInputException("Invalid input provided for 'perPage'.");
+
+        PaginationDTO<PhoneDTO> paginationDTO = PaginationDTO.of(
+            phoneDTOs,
+            page,
+            perPage
+        );
+        return ResponseEntity.ok(paginationDTO);
     }
 
     @GetMapping("/{phoneId}")

--- a/src/main/java/com/sarapis/orservice/controller/ProgramController.java
+++ b/src/main/java/com/sarapis/orservice/controller/ProgramController.java
@@ -22,8 +22,8 @@ public class ProgramController {
     }
 
   @GetMapping
-  public ResponseEntity<PaginationDTO<ProgramDTO>> getAllPrograms(@RequestParam(defaultValue = "1") Integer page,
-                                                                  @RequestParam(defaultValue = "10") Integer perPage) {
+  public ResponseEntity<PaginationDTO<ProgramDTO>> getAllPrograms(@RequestParam(name = "page", defaultValue = "1") int page,
+                                                                  @RequestParam(name = "perPage", defaultValue = "10") int perPage) {
     List<ProgramDTO> programDTOs = this.programService.getAllPrograms();
 
     try {

--- a/src/main/java/com/sarapis/orservice/controller/ProgramController.java
+++ b/src/main/java/com/sarapis/orservice/controller/ProgramController.java
@@ -22,12 +22,17 @@ public class ProgramController {
   public ResponseEntity<PaginationDTO<ProgramDTO>> getAllPrograms(@RequestParam(defaultValue = "1") Integer page,
                                                                   @RequestParam(defaultValue = "10") Integer perPage) {
     List<ProgramDTO> programDTOs = this.programService.getAllPrograms();
-    PaginationDTO<ProgramDTO> paginationDTO = PaginationDTO.of(
-        programDTOs,
-        page,
-        perPage
-    );
-    return ResponseEntity.ok(paginationDTO);
+
+    try {
+      PaginationDTO<ProgramDTO> paginationDTO = PaginationDTO.of(
+              programDTOs,
+              page,
+              perPage
+      );
+      return ResponseEntity.ok(paginationDTO);
+    } catch (RuntimeException e) {
+      return ResponseEntity.badRequest().build();
+    }
   }
 
   @GetMapping("/{id}")

--- a/src/main/java/com/sarapis/orservice/controller/ProgramController.java
+++ b/src/main/java/com/sarapis/orservice/controller/ProgramController.java
@@ -1,18 +1,12 @@
 package com.sarapis.orservice.controller;
 
+import com.sarapis.orservice.dto.PaginationDTO;
 import com.sarapis.orservice.dto.ProgramDTO;
 import com.sarapis.orservice.service.ProgramService;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/programs")
@@ -25,9 +19,15 @@ public class ProgramController {
   }
 
   @GetMapping
-  public ResponseEntity<List<ProgramDTO>> getAllPrograms() {
+  public ResponseEntity<PaginationDTO<ProgramDTO>> getAllPrograms(@RequestParam(defaultValue = "1") Integer page,
+                                                                  @RequestParam(defaultValue = "10") Integer perPage) {
     List<ProgramDTO> programDTOs = this.programService.getAllPrograms();
-    return ResponseEntity.ok(programDTOs);
+    PaginationDTO<ProgramDTO> paginationDTO = PaginationDTO.of(
+        programDTOs,
+        page,
+        perPage
+    );
+    return ResponseEntity.ok(paginationDTO);
   }
 
   @GetMapping("/{id}")

--- a/src/main/java/com/sarapis/orservice/controller/ProgramController.java
+++ b/src/main/java/com/sarapis/orservice/controller/ProgramController.java
@@ -4,6 +4,7 @@ import com.sarapis.orservice.dto.PaginationDTO;
 import com.sarapis.orservice.dto.ProgramDTO;
 import com.sarapis.orservice.dto.upsert.UpsertLocationDTO;
 import com.sarapis.orservice.dto.upsert.UpsertProgramDTO;
+import com.sarapis.orservice.exception.InvalidInputException;
 import com.sarapis.orservice.service.ProgramService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -26,16 +27,15 @@ public class ProgramController {
                                                                   @RequestParam(name = "perPage", defaultValue = "10") int perPage) {
     List<ProgramDTO> programDTOs = this.programService.getAllPrograms();
 
-    try {
-      PaginationDTO<ProgramDTO> paginationDTO = PaginationDTO.of(
-              programDTOs,
-              page,
-              perPage
-      );
-      return ResponseEntity.ok(paginationDTO);
-    } catch (RuntimeException e) {
-      return ResponseEntity.badRequest().build();
-    }
+    if(page <= 0) throw new InvalidInputException("Invalid input provided for 'page'.");
+    if(perPage <= 0) throw new InvalidInputException("Invalid input provided for 'perPage'.");
+
+    PaginationDTO<ProgramDTO> paginationDTO = PaginationDTO.of(
+        programDTOs,
+        page,
+        perPage
+    );
+    return ResponseEntity.ok(paginationDTO);
   }
 
     @GetMapping("/{programId}")

--- a/src/main/java/com/sarapis/orservice/controller/ScheduleController.java
+++ b/src/main/java/com/sarapis/orservice/controller/ScheduleController.java
@@ -24,12 +24,17 @@ public class ScheduleController {
     public ResponseEntity<PaginationDTO<ScheduleDTO>> getSchedules(@RequestParam(defaultValue = "1") Integer page,
                                                                    @RequestParam(defaultValue = "10") Integer perPage) {
         List<ScheduleDTO> scheduleDTOs = this.scheduleService.getAllSchedules();
-        PaginationDTO<ScheduleDTO> paginationDTO = PaginationDTO.of(
-            scheduleDTOs,
-            page,
-            perPage
-        );
-        return ResponseEntity.ok(paginationDTO);
+
+        try {
+            PaginationDTO<ScheduleDTO> paginationDTO = PaginationDTO.of(
+                    scheduleDTOs,
+                    page,
+                    perPage
+            );
+            return ResponseEntity.ok(paginationDTO);
+        } catch (RuntimeException e) {
+            return ResponseEntity.badRequest().build();
+        }
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/com/sarapis/orservice/controller/ScheduleController.java
+++ b/src/main/java/com/sarapis/orservice/controller/ScheduleController.java
@@ -1,5 +1,6 @@
 package com.sarapis.orservice.controller;
 
+import com.sarapis.orservice.dto.PaginationDTO;
 import com.sarapis.orservice.dto.ScheduleDTO;
 import com.sarapis.orservice.service.ScheduleService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,9 +21,15 @@ public class ScheduleController {
     }
 
     @GetMapping
-    public ResponseEntity<List<ScheduleDTO>> getSchedules() {
+    public ResponseEntity<PaginationDTO<ScheduleDTO>> getSchedules(@RequestParam(defaultValue = "1") Integer page,
+                                                                   @RequestParam(defaultValue = "10") Integer perPage) {
         List<ScheduleDTO> scheduleDTOs = this.scheduleService.getAllSchedules();
-        return ResponseEntity.ok(scheduleDTOs);
+        PaginationDTO<ScheduleDTO> paginationDTO = PaginationDTO.of(
+            scheduleDTOs,
+            page,
+            perPage
+        );
+        return ResponseEntity.ok(paginationDTO);
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/com/sarapis/orservice/controller/ScheduleController.java
+++ b/src/main/java/com/sarapis/orservice/controller/ScheduleController.java
@@ -2,6 +2,7 @@ package com.sarapis.orservice.controller;
 
 import com.sarapis.orservice.dto.PaginationDTO;
 import com.sarapis.orservice.dto.ScheduleDTO;
+import com.sarapis.orservice.exception.InvalidInputException;
 import com.sarapis.orservice.service.ScheduleService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -24,16 +25,15 @@ public class ScheduleController {
                                                                    @RequestParam(name = "perPage", defaultValue = "10") int perPage) {
         List<ScheduleDTO> scheduleDTOs = this.scheduleService.getAllSchedules();
 
-        try {
-            PaginationDTO<ScheduleDTO> paginationDTO = PaginationDTO.of(
-                    scheduleDTOs,
-                    page,
-                    perPage
-            );
-            return ResponseEntity.ok(paginationDTO);
-        } catch (RuntimeException e) {
-            return ResponseEntity.badRequest().build();
-        }
+        if(page <= 0) throw new InvalidInputException("Invalid input provided for 'page'.");
+        if(perPage <= 0) throw new InvalidInputException("Invalid input provided for 'perPage'.");
+
+        PaginationDTO<ScheduleDTO> paginationDTO = PaginationDTO.of(
+            scheduleDTOs,
+            page,
+            perPage
+        );
+        return ResponseEntity.ok(paginationDTO);
     }
 
     @GetMapping("/{scheduleId}")

--- a/src/main/java/com/sarapis/orservice/controller/ScheduleController.java
+++ b/src/main/java/com/sarapis/orservice/controller/ScheduleController.java
@@ -20,8 +20,8 @@ public class ScheduleController {
     }
 
     @GetMapping
-    public ResponseEntity<PaginationDTO<ScheduleDTO>> getSchedules(@RequestParam(defaultValue = "1") Integer page,
-                                                                   @RequestParam(defaultValue = "10") Integer perPage) {
+    public ResponseEntity<PaginationDTO<ScheduleDTO>> getSchedules(@RequestParam(name = "page", defaultValue = "1") int page,
+                                                                   @RequestParam(name = "perPage", defaultValue = "10") int perPage) {
         List<ScheduleDTO> scheduleDTOs = this.scheduleService.getAllSchedules();
 
         try {

--- a/src/main/java/com/sarapis/orservice/controller/ServiceAreaController.java
+++ b/src/main/java/com/sarapis/orservice/controller/ServiceAreaController.java
@@ -25,12 +25,17 @@ public class ServiceAreaController {
     public ResponseEntity<PaginationDTO<ServiceAreaDTO>> getAllServiceAreas(@RequestParam(defaultValue = "1") Integer page,
                                                                             @RequestParam(defaultValue = "10") Integer perPage) {
         List<ServiceAreaDTO> serviceAreaDTOs = serviceAreaService.getAllServiceAreas();
-        PaginationDTO<ServiceAreaDTO> paginationDTO = PaginationDTO.of(
-            serviceAreaDTOs,
-            page,
-            perPage
-        );
-        return ResponseEntity.ok(paginationDTO);
+
+        try {
+            PaginationDTO<ServiceAreaDTO> paginationDTO = PaginationDTO.of(
+                    serviceAreaDTOs,
+                    page,
+                    perPage
+            );
+            return ResponseEntity.ok(paginationDTO);
+        } catch (RuntimeException e) {
+            return ResponseEntity.badRequest().build();
+        }
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/com/sarapis/orservice/controller/ServiceAreaController.java
+++ b/src/main/java/com/sarapis/orservice/controller/ServiceAreaController.java
@@ -21,8 +21,8 @@ public class ServiceAreaController {
     }
 
     @GetMapping
-    public ResponseEntity<PaginationDTO<ServiceAreaDTO>> getAllServiceAreas(@RequestParam(defaultValue = "1") Integer page,
-                                                                            @RequestParam(defaultValue = "10") Integer perPage) {
+    public ResponseEntity<PaginationDTO<ServiceAreaDTO>> getAllServiceAreas(@RequestParam(name = "page", defaultValue = "1") int page,
+                                                                            @RequestParam(name = "perPage", defaultValue = "10") int perPage) {
         List<ServiceAreaDTO> serviceAreaDTOs = serviceAreaService.getAllServiceAreas();
 
         try {

--- a/src/main/java/com/sarapis/orservice/controller/ServiceAreaController.java
+++ b/src/main/java/com/sarapis/orservice/controller/ServiceAreaController.java
@@ -2,6 +2,7 @@ package com.sarapis.orservice.controller;
 
 import com.sarapis.orservice.dto.PaginationDTO;
 import com.sarapis.orservice.dto.ServiceAreaDTO;
+import com.sarapis.orservice.exception.InvalidInputException;
 import com.sarapis.orservice.service.ServiceAreaService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -25,16 +26,15 @@ public class ServiceAreaController {
                                                                             @RequestParam(name = "perPage", defaultValue = "10") int perPage) {
         List<ServiceAreaDTO> serviceAreaDTOs = serviceAreaService.getAllServiceAreas();
 
-        try {
-            PaginationDTO<ServiceAreaDTO> paginationDTO = PaginationDTO.of(
-                    serviceAreaDTOs,
-                    page,
-                    perPage
-            );
-            return ResponseEntity.ok(paginationDTO);
-        } catch (RuntimeException e) {
-            return ResponseEntity.badRequest().build();
-        }
+        if(page <= 0) throw new InvalidInputException("Invalid input provided for 'page'.");
+        if(perPage <= 0) throw new InvalidInputException("Invalid input provided for 'perPage'.");
+
+        PaginationDTO<ServiceAreaDTO> paginationDTO = PaginationDTO.of(
+            serviceAreaDTOs,
+            page,
+            perPage
+        );
+        return ResponseEntity.ok(paginationDTO);
     }
 
     @GetMapping("/{serviceAreaId}")

--- a/src/main/java/com/sarapis/orservice/controller/ServiceAreaController.java
+++ b/src/main/java/com/sarapis/orservice/controller/ServiceAreaController.java
@@ -1,5 +1,6 @@
 package com.sarapis.orservice.controller;
 
+import com.sarapis.orservice.dto.PaginationDTO;
 import com.sarapis.orservice.dto.ServiceAreaDTO;
 import com.sarapis.orservice.service.ServiceAreaService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -21,9 +22,15 @@ public class ServiceAreaController {
     }
 
     @GetMapping
-    public ResponseEntity<List<ServiceAreaDTO>> getAllServiceAreas() {
+    public ResponseEntity<PaginationDTO<ServiceAreaDTO>> getAllServiceAreas(@RequestParam(defaultValue = "1") Integer page,
+                                                                            @RequestParam(defaultValue = "10") Integer perPage) {
         List<ServiceAreaDTO> serviceAreaDTOs = serviceAreaService.getAllServiceAreas();
-        return ResponseEntity.ok(serviceAreaDTOs);
+        PaginationDTO<ServiceAreaDTO> paginationDTO = PaginationDTO.of(
+            serviceAreaDTOs,
+            page,
+            perPage
+        );
+        return ResponseEntity.ok(paginationDTO);
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/com/sarapis/orservice/controller/ServiceAtLocationController.java
+++ b/src/main/java/com/sarapis/orservice/controller/ServiceAtLocationController.java
@@ -21,8 +21,8 @@ public class ServiceAtLocationController {
     }
 
   @GetMapping
-  public ResponseEntity<PaginationDTO<ServiceAtLocationDTO>> getAllServiceAtLocations(@RequestParam(defaultValue = "1") Integer page,
-                                                                                      @RequestParam(defaultValue = "10") Integer perPage) {
+  public ResponseEntity<PaginationDTO<ServiceAtLocationDTO>> getAllServiceAtLocations(@RequestParam(name = "page", defaultValue = "1") int page,
+                                                                                      @RequestParam(name = "perPage", defaultValue = "10") int perPage) {
     List<ServiceAtLocationDTO> servLocDTOs = this.serviceAtLocationService.getAllServicesAtLocation();
 
     try {

--- a/src/main/java/com/sarapis/orservice/controller/ServiceAtLocationController.java
+++ b/src/main/java/com/sarapis/orservice/controller/ServiceAtLocationController.java
@@ -31,13 +31,17 @@ public class ServiceAtLocationController {
   public ResponseEntity<PaginationDTO<ServiceAtLocationDTO>> getAllServiceAtLocations(@RequestParam(defaultValue = "1") Integer page,
                                                                                       @RequestParam(defaultValue = "10") Integer perPage) {
     List<ServiceAtLocationDTO> servLocDTOs = this.serviceAtLocationService.getAllServicesAtLocation();
-    PaginationDTO<ServiceAtLocationDTO> paginationDTO = PaginationDTO.of(
-        servLocDTOs,
-        page,
-        perPage
-    );
 
-    return ResponseEntity.ok(paginationDTO);
+    try {
+      PaginationDTO<ServiceAtLocationDTO> paginationDTO = PaginationDTO.of(
+              servLocDTOs,
+              page,
+              perPage
+      );
+      return ResponseEntity.ok(paginationDTO);
+    } catch (RuntimeException e) {
+      return ResponseEntity.badRequest().build();
+    }
   }
 
   @GetMapping("/{id}")

--- a/src/main/java/com/sarapis/orservice/controller/ServiceAtLocationController.java
+++ b/src/main/java/com/sarapis/orservice/controller/ServiceAtLocationController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -27,17 +28,13 @@ public class ServiceAtLocationController {
   }
 
   @GetMapping
-  public ResponseEntity<PaginationDTO<ServiceAtLocationDTO>> getAllServiceAtLocations() {
+  public ResponseEntity<PaginationDTO<ServiceAtLocationDTO>> getAllServiceAtLocations(@RequestParam(defaultValue = "1") Integer page,
+                                                                                      @RequestParam(defaultValue = "10") Integer perPage) {
     List<ServiceAtLocationDTO> servLocDTOs = this.serviceAtLocationService.getAllServicesAtLocation();
     PaginationDTO<ServiceAtLocationDTO> paginationDTO = PaginationDTO.of(
-            servLocDTOs.size(),
-            1,
-            1,
-            servLocDTOs.size(),
-            true,
-            false,
-            false,
-            servLocDTOs
+        servLocDTOs,
+        page,
+        perPage
     );
 
     return ResponseEntity.ok(paginationDTO);

--- a/src/main/java/com/sarapis/orservice/controller/ServiceAtLocationController.java
+++ b/src/main/java/com/sarapis/orservice/controller/ServiceAtLocationController.java
@@ -3,6 +3,7 @@ package com.sarapis.orservice.controller;
 import com.sarapis.orservice.dto.PaginationDTO;
 import com.sarapis.orservice.dto.ServiceAtLocationDTO;
 import com.sarapis.orservice.dto.upsert.UpsertServiceAtLocationDTO;
+import com.sarapis.orservice.exception.InvalidInputException;
 import com.sarapis.orservice.service.ServiceAtLocationService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -25,16 +26,16 @@ public class ServiceAtLocationController {
                                                                                       @RequestParam(name = "perPage", defaultValue = "10") int perPage) {
     List<ServiceAtLocationDTO> servLocDTOs = this.serviceAtLocationService.getAllServicesAtLocation();
 
-    try {
-      PaginationDTO<ServiceAtLocationDTO> paginationDTO = PaginationDTO.of(
-              servLocDTOs,
-              page,
-              perPage
-      );
-      return ResponseEntity.ok(paginationDTO);
-    } catch (RuntimeException e) {
-      return ResponseEntity.badRequest().build();
-    }
+    if(page <= 0) throw new InvalidInputException("Invalid input provided for 'page'.");
+    if(perPage <= 0) throw new InvalidInputException("Invalid input provided for 'perPage'.");
+
+
+    PaginationDTO<ServiceAtLocationDTO> paginationDTO = PaginationDTO.of(
+        servLocDTOs,
+        page,
+        perPage
+    );
+    return ResponseEntity.ok(paginationDTO);
   }
 
     @GetMapping("/{serviceAtLocationId}")

--- a/src/main/java/com/sarapis/orservice/controller/ServiceController.java
+++ b/src/main/java/com/sarapis/orservice/controller/ServiceController.java
@@ -21,8 +21,8 @@ public class ServiceController {
     }
 
   @GetMapping
-  public ResponseEntity<PaginationDTO<ServiceDTO>> getAllServices(@RequestParam(defaultValue = "1") Integer page,
-                                                                  @RequestParam(defaultValue = "10") Integer perPage) {
+  public ResponseEntity<PaginationDTO<ServiceDTO>> getAllServices(@RequestParam(name = "page", defaultValue = "1") int page,
+                                                                  @RequestParam(name = "perPage", defaultValue = "10") int perPage) {
     List<ServiceDTO> services = serviceService.getAllServices();
 
     try {

--- a/src/main/java/com/sarapis/orservice/controller/ServiceController.java
+++ b/src/main/java/com/sarapis/orservice/controller/ServiceController.java
@@ -30,12 +30,17 @@ public class ServiceController {
   public ResponseEntity<PaginationDTO<ServiceDTO>> getAllServices(@RequestParam(defaultValue = "1") Integer page,
                                                                   @RequestParam(defaultValue = "10") Integer perPage) {
     List<ServiceDTO> services = serviceService.getAllServices();
-    PaginationDTO<ServiceDTO> paginationDTO = PaginationDTO.of(
-        services,
-        page,
-        perPage
-    );
-    return ResponseEntity.ok(paginationDTO);
+
+    try {
+      PaginationDTO<ServiceDTO> paginationDTO = PaginationDTO.of(
+              services,
+              page,
+              perPage
+      );
+      return ResponseEntity.ok(paginationDTO);
+    } catch (RuntimeException e) {
+      return ResponseEntity.badRequest().build();
+    }
   }
 
   @GetMapping("/{id}")

--- a/src/main/java/com/sarapis/orservice/controller/ServiceController.java
+++ b/src/main/java/com/sarapis/orservice/controller/ServiceController.java
@@ -3,6 +3,7 @@ package com.sarapis.orservice.controller;
 import com.sarapis.orservice.dto.PaginationDTO;
 import com.sarapis.orservice.dto.ServiceDTO;
 import com.sarapis.orservice.dto.upsert.UpsertServiceDTO;
+import com.sarapis.orservice.exception.InvalidInputException;
 import com.sarapis.orservice.service.ServiceService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -25,16 +26,15 @@ public class ServiceController {
                                                                   @RequestParam(name = "perPage", defaultValue = "10") int perPage) {
     List<ServiceDTO> services = serviceService.getAllServices();
 
-    try {
-      PaginationDTO<ServiceDTO> paginationDTO = PaginationDTO.of(
-              services,
-              page,
-              perPage
-      );
-      return ResponseEntity.ok(paginationDTO);
-    } catch (RuntimeException e) {
-      return ResponseEntity.badRequest().build();
-    }
+    if(page <= 0) throw new InvalidInputException("Invalid input provided for 'page'.");
+    if(perPage <= 0) throw new InvalidInputException("Invalid input provided for 'perPage'.");
+
+    PaginationDTO<ServiceDTO> paginationDTO = PaginationDTO.of(
+        services,
+        page,
+        perPage
+    );
+    return ResponseEntity.ok(paginationDTO);
   }
 
     @GetMapping("/{serviceId}")

--- a/src/main/java/com/sarapis/orservice/controller/ServiceController.java
+++ b/src/main/java/com/sarapis/orservice/controller/ServiceController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -26,17 +27,13 @@ public class ServiceController {
   }
 
   @GetMapping
-  public ResponseEntity<PaginationDTO<ServiceDTO>> getAllServices() {
+  public ResponseEntity<PaginationDTO<ServiceDTO>> getAllServices(@RequestParam(defaultValue = "1") Integer page,
+                                                                  @RequestParam(defaultValue = "10") Integer perPage) {
     List<ServiceDTO> services = serviceService.getAllServices();
     PaginationDTO<ServiceDTO> paginationDTO = PaginationDTO.of(
-        services.size(),
-        1,
-        1,
-        services.size(),
-        true,
-        false,
-        false,
-        services
+        services,
+        page,
+        perPage
     );
     return ResponseEntity.ok(paginationDTO);
   }

--- a/src/main/java/com/sarapis/orservice/controller/TaxonomyController.java
+++ b/src/main/java/com/sarapis/orservice/controller/TaxonomyController.java
@@ -20,8 +20,8 @@ public class TaxonomyController {
     }
 
   @GetMapping
-  public ResponseEntity<PaginationDTO<TaxonomyDTO>> getAllTaxonomies(@RequestParam(defaultValue = "1") Integer page,
-                                                                     @RequestParam(defaultValue = "10") Integer perPage) {
+  public ResponseEntity<PaginationDTO<TaxonomyDTO>> getAllTaxonomies(@RequestParam(name = "page", defaultValue = "1") int page,
+                                                                     @RequestParam(name = "perPage", defaultValue = "10") int perPage) {
     List<TaxonomyDTO> taxonomyDTOs = this.taxonomyService.getAllTaxonomies();
 
     try {

--- a/src/main/java/com/sarapis/orservice/controller/TaxonomyController.java
+++ b/src/main/java/com/sarapis/orservice/controller/TaxonomyController.java
@@ -12,7 +12,10 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/taxonomies")
@@ -25,8 +28,15 @@ public class TaxonomyController {
   }
 
   @GetMapping
-  public ResponseEntity<PaginationDTO<TaxonomyDTO>> getAllTaxonomies() {
-    return null;
+  public ResponseEntity<PaginationDTO<TaxonomyDTO>> getAllTaxonomies(@RequestParam(defaultValue = "1") Integer page,
+                                                                     @RequestParam(defaultValue = "10") Integer perPage) {
+    List<TaxonomyDTO> taxonomyDTOs = this.taxonomyService.getAllTaxonomies();
+    PaginationDTO<TaxonomyDTO> paginationDTO = PaginationDTO.of(
+        taxonomyDTOs,
+        page,
+        perPage
+    );
+    return ResponseEntity.ok(paginationDTO);
   }
 
   @GetMapping("/{id}")

--- a/src/main/java/com/sarapis/orservice/controller/TaxonomyController.java
+++ b/src/main/java/com/sarapis/orservice/controller/TaxonomyController.java
@@ -2,6 +2,7 @@ package com.sarapis.orservice.controller;
 
 import com.sarapis.orservice.dto.PaginationDTO;
 import com.sarapis.orservice.dto.TaxonomyDTO;
+import com.sarapis.orservice.exception.InvalidInputException;
 import com.sarapis.orservice.service.TaxonomyService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -24,16 +25,15 @@ public class TaxonomyController {
                                                                      @RequestParam(name = "perPage", defaultValue = "10") int perPage) {
     List<TaxonomyDTO> taxonomyDTOs = this.taxonomyService.getAllTaxonomies();
 
-    try {
-      PaginationDTO<TaxonomyDTO> paginationDTO = PaginationDTO.of(
-              taxonomyDTOs,
-              page,
-              perPage
-      );
-      return ResponseEntity.ok(paginationDTO);
-    } catch (RuntimeException e) {
-      return ResponseEntity.badRequest().build();
-    }
+    if(page <= 0) throw new InvalidInputException("Invalid input provided for 'page'.");
+    if(perPage <= 0) throw new InvalidInputException("Invalid input provided for 'perPage'.");
+
+    PaginationDTO<TaxonomyDTO> paginationDTO = PaginationDTO.of(
+        taxonomyDTOs,
+        page,
+        perPage
+    );
+    return ResponseEntity.ok(paginationDTO);
   }
 
     @GetMapping("/{taxonomyId}")

--- a/src/main/java/com/sarapis/orservice/controller/TaxonomyController.java
+++ b/src/main/java/com/sarapis/orservice/controller/TaxonomyController.java
@@ -31,12 +31,17 @@ public class TaxonomyController {
   public ResponseEntity<PaginationDTO<TaxonomyDTO>> getAllTaxonomies(@RequestParam(defaultValue = "1") Integer page,
                                                                      @RequestParam(defaultValue = "10") Integer perPage) {
     List<TaxonomyDTO> taxonomyDTOs = this.taxonomyService.getAllTaxonomies();
-    PaginationDTO<TaxonomyDTO> paginationDTO = PaginationDTO.of(
-        taxonomyDTOs,
-        page,
-        perPage
-    );
-    return ResponseEntity.ok(paginationDTO);
+
+    try {
+      PaginationDTO<TaxonomyDTO> paginationDTO = PaginationDTO.of(
+              taxonomyDTOs,
+              page,
+              perPage
+      );
+      return ResponseEntity.ok(paginationDTO);
+    } catch (RuntimeException e) {
+      return ResponseEntity.badRequest().build();
+    }
   }
 
   @GetMapping("/{id}")

--- a/src/main/java/com/sarapis/orservice/controller/TaxonomyTermController.java
+++ b/src/main/java/com/sarapis/orservice/controller/TaxonomyTermController.java
@@ -20,8 +20,8 @@ public class TaxonomyTermController {
     }
 
   @GetMapping
-  public ResponseEntity<PaginationDTO<TaxonomyTermDTO>> getAllTaxonomyTerms(@RequestParam(defaultValue = "1") Integer page,
-                                                                            @RequestParam(defaultValue = "10") Integer perPage) {
+  public ResponseEntity<PaginationDTO<TaxonomyTermDTO>> getAllTaxonomyTerms(@RequestParam(name = "page", defaultValue = "1") int page,
+                                                                            @RequestParam(name = "perPage", defaultValue = "10") int perPage) {
     List<TaxonomyTermDTO> taxonomyTermDTOs = this.taxonomyTermService.getAllTaxonomyTerms();
 
     try {

--- a/src/main/java/com/sarapis/orservice/controller/TaxonomyTermController.java
+++ b/src/main/java/com/sarapis/orservice/controller/TaxonomyTermController.java
@@ -31,12 +31,17 @@ public class TaxonomyTermController {
   public ResponseEntity<PaginationDTO<TaxonomyTermDTO>> getAllTaxonomyTerms(@RequestParam(defaultValue = "1") Integer page,
                                                                             @RequestParam(defaultValue = "10") Integer perPage) {
     List<TaxonomyTermDTO> taxonomyTermDTOs = this.taxonomyTermService.getAllTaxonomyTerms();
-    PaginationDTO<TaxonomyTermDTO> paginationDTO = PaginationDTO.of(
-        taxonomyTermDTOs,
-        page,
-        perPage
-    );
-    return ResponseEntity.ok(paginationDTO);
+
+    try {
+      PaginationDTO<TaxonomyTermDTO> paginationDTO = PaginationDTO.of(
+              taxonomyTermDTOs,
+              page,
+              perPage
+      );
+      return ResponseEntity.ok(paginationDTO);
+    } catch (RuntimeException e) {
+      return ResponseEntity.badRequest().build();
+    }
   }
 
   @GetMapping("/{id}")

--- a/src/main/java/com/sarapis/orservice/controller/TaxonomyTermController.java
+++ b/src/main/java/com/sarapis/orservice/controller/TaxonomyTermController.java
@@ -2,6 +2,7 @@ package com.sarapis.orservice.controller;
 
 import com.sarapis.orservice.dto.PaginationDTO;
 import com.sarapis.orservice.dto.TaxonomyTermDTO;
+import com.sarapis.orservice.exception.InvalidInputException;
 import com.sarapis.orservice.service.TaxonomyTermService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -24,16 +25,15 @@ public class TaxonomyTermController {
                                                                             @RequestParam(name = "perPage", defaultValue = "10") int perPage) {
     List<TaxonomyTermDTO> taxonomyTermDTOs = this.taxonomyTermService.getAllTaxonomyTerms();
 
-    try {
-      PaginationDTO<TaxonomyTermDTO> paginationDTO = PaginationDTO.of(
-              taxonomyTermDTOs,
-              page,
-              perPage
-      );
-      return ResponseEntity.ok(paginationDTO);
-    } catch (RuntimeException e) {
-      return ResponseEntity.badRequest().build();
-    }
+    if(page <= 0) throw new InvalidInputException("Invalid input provided for 'page'.");
+    if(perPage <= 0) throw new InvalidInputException("Invalid input provided for 'perPage'.");
+
+    PaginationDTO<TaxonomyTermDTO> paginationDTO = PaginationDTO.of(
+        taxonomyTermDTOs,
+        page,
+        perPage
+    );
+    return ResponseEntity.ok(paginationDTO);
   }
 
     @GetMapping("/{id}")

--- a/src/main/java/com/sarapis/orservice/controller/TaxonomyTermController.java
+++ b/src/main/java/com/sarapis/orservice/controller/TaxonomyTermController.java
@@ -12,7 +12,10 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/taxonomy_terms")
@@ -25,8 +28,15 @@ public class TaxonomyTermController {
   }
 
   @GetMapping
-  public ResponseEntity<PaginationDTO<TaxonomyTermDTO>> getAllTaxonomyTerms() {
-    return null;
+  public ResponseEntity<PaginationDTO<TaxonomyTermDTO>> getAllTaxonomyTerms(@RequestParam(defaultValue = "1") Integer page,
+                                                                            @RequestParam(defaultValue = "10") Integer perPage) {
+    List<TaxonomyTermDTO> taxonomyTermDTOs = this.taxonomyTermService.getAllTaxonomyTerms();
+    PaginationDTO<TaxonomyTermDTO> paginationDTO = PaginationDTO.of(
+        taxonomyTermDTOs,
+        page,
+        perPage
+    );
+    return ResponseEntity.ok(paginationDTO);
   }
 
   @GetMapping("/{id}")

--- a/src/main/java/com/sarapis/orservice/dto/PaginationDTO.java
+++ b/src/main/java/com/sarapis/orservice/dto/PaginationDTO.java
@@ -1,6 +1,6 @@
 package com.sarapis.orservice.dto;
 
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import lombok.*;
@@ -18,6 +18,15 @@ public class PaginationDTO<T> {
     private boolean lastPage;
     private boolean empty;
     private List<T> contents;
+
+    public static <T> List<T> getPaginatedSubset(List<T> contents, int pageNumber, int perPage) {
+        int totalItems = contents.size();
+        if (pageNumber < 1 || perPage <= 0) return Collections.emptyList();
+        int start = (pageNumber - 1) * perPage;
+        if (start >= totalItems) return Collections.emptyList();
+        int end = Math.min(start + perPage, totalItems);
+        return contents.subList(start, end);
+    }
 
     public static <T> PaginationDTO<T> of(int totalItems, int totalPages, int pageNumber, int size, boolean firstPage,
             boolean lastPage, boolean empty, List<T> contents) {
@@ -49,10 +58,7 @@ public class PaginationDTO<T> {
         }
 
         // Get only the content that will be shown
-        List<T> contentSubset = new ArrayList<>();
-        for(int i = (pageNumber - 1) * perPage; i < Math.min(pageNumber * perPage, totalItems); i++) {
-            contentSubset.add(contents.get(i));
-        }
+        List<T> contentSubset = getPaginatedSubset(contents, pageNumber, perPage);
 
         int pageSize = contentSubset.size();
         boolean isFirstPage = pageNumber == 1;

--- a/src/main/java/com/sarapis/orservice/dto/PaginationDTO.java
+++ b/src/main/java/com/sarapis/orservice/dto/PaginationDTO.java
@@ -43,19 +43,8 @@ public class PaginationDTO<T> {
     }
 
     public static <T> PaginationDTO<T> of(List<T> contents, int pageNumber, int perPage) {
-        if(perPage <= 0) {
-            throw new RuntimeException("Invalid perPage value provided");
-        }
-        if(pageNumber <= 0) {
-            throw new RuntimeException("Invalid pageNumber value provided");
-        }
-
         int totalItems = contents.size();
         int totalPages = Math.max((int) Math.ceil((double) totalItems / perPage), 1);
-
-        if(pageNumber > totalPages) {
-            throw new RuntimeException("Provided pageNumber exceeds last page");
-        }
 
         // Get only the content that will be shown
         List<T> contentSubset = getPaginatedSubset(contents, pageNumber, perPage);

--- a/src/main/java/com/sarapis/orservice/dto/PaginationDTO.java
+++ b/src/main/java/com/sarapis/orservice/dto/PaginationDTO.java
@@ -48,7 +48,7 @@ public class PaginationDTO<T> {
         }
 
         int totalItems = contents.size();
-        int totalPages = (int) Math.ceil((double) totalItems / perPage);
+        int totalPages = (totalItems / perPage) + 1;
 
         if(pageNumber > totalPages) {
             throw new RuntimeException("Provided pageNumber exceeds last page");

--- a/src/main/java/com/sarapis/orservice/dto/PaginationDTO.java
+++ b/src/main/java/com/sarapis/orservice/dto/PaginationDTO.java
@@ -40,8 +40,19 @@ public class PaginationDTO<T> {
     }
 
     public static <T> PaginationDTO<T> of(List<T> contents, int pageNumber, int perPage) {
+        if(perPage < 0) {
+            throw new RuntimeException("Invalid perPage value provided");
+        }
+        if(pageNumber < 0) {
+            throw new RuntimeException("Invalid pageNumber value provided");
+        }
+
         int totalItems = contents.size();
         int totalPages = (int) Math.ceil((double) totalItems / perPage);
+
+        if(pageNumber > totalPages) {
+            throw new RuntimeException("Provided pageNumber exceeds last page");
+        }
 
         // Get only the content that will be shown
         List<T> contentSubset = new ArrayList<>();

--- a/src/main/java/com/sarapis/orservice/dto/PaginationDTO.java
+++ b/src/main/java/com/sarapis/orservice/dto/PaginationDTO.java
@@ -48,7 +48,7 @@ public class PaginationDTO<T> {
         }
 
         int totalItems = contents.size();
-        int totalPages = (totalItems / perPage) + 1;
+        int totalPages = Math.max((int) Math.ceil((double) totalItems / perPage), 1);
 
         if(pageNumber > totalPages) {
             throw new RuntimeException("Provided pageNumber exceeds last page");

--- a/src/main/java/com/sarapis/orservice/dto/PaginationDTO.java
+++ b/src/main/java/com/sarapis/orservice/dto/PaginationDTO.java
@@ -40,10 +40,10 @@ public class PaginationDTO<T> {
     }
 
     public static <T> PaginationDTO<T> of(List<T> contents, int pageNumber, int perPage) {
-        if(perPage < 0) {
+        if(perPage <= 0) {
             throw new RuntimeException("Invalid perPage value provided");
         }
-        if(pageNumber < 0) {
+        if(pageNumber <= 0) {
             throw new RuntimeException("Invalid pageNumber value provided");
         }
 

--- a/src/main/java/com/sarapis/orservice/dto/PaginationDTO.java
+++ b/src/main/java/com/sarapis/orservice/dto/PaginationDTO.java
@@ -1,5 +1,6 @@
 package com.sarapis.orservice.dto;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import lombok.*;
@@ -36,5 +37,32 @@ public class PaginationDTO<T> {
         paginationDTO.setEmpty(empty);
         paginationDTO.setContents(contents);
         return paginationDTO;
+    }
+
+    public static <T> PaginationDTO<T> of(List<T> contents, int pageNumber, int perPage) {
+        int totalItems = contents.size();
+        int totalPages = (int) Math.ceil((double) totalItems / perPage);
+
+        // Get only the content that will be shown
+        List<T> contentSubset = new ArrayList<>();
+        for(int i = (pageNumber - 1) * perPage; i < Math.min(pageNumber * perPage, totalItems); i++) {
+            contentSubset.add(contents.get(i));
+        }
+
+        int pageSize = contentSubset.size();
+        boolean isFirstPage = pageNumber == 1;
+        boolean isLastPage = pageNumber == totalPages;
+        boolean isEmpty = pageSize == 0;
+
+        return PaginationDTO.of(
+                totalItems,         // total_items (Query Result Size)
+                totalPages,         // total_pages
+                pageNumber,         // page_number [User-provided]
+                pageSize,           // size: (Query Result to be shown on this page_number)
+                isFirstPage,        // first_page
+                isLastPage,         // last_page
+                isEmpty,            // empty
+                contentSubset       // content (for this page_number)
+        );
     }
 }

--- a/src/main/java/com/sarapis/orservice/exception/InvalidInputException.java
+++ b/src/main/java/com/sarapis/orservice/exception/InvalidInputException.java
@@ -1,0 +1,11 @@
+package com.sarapis.orservice.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(value = HttpStatus.BAD_REQUEST)
+public class InvalidInputException extends RuntimeException {
+    public InvalidInputException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
Pagination support for controllers with getAll routes.

Append a query string with arguments `page=<int>` and `perPage=<int>` to control pageNumber and items shown on a given page respectively. Example, `http://path/to/resource?page=2&perPage=10` gets the second page with at most 10 items shown on it. These options do not need to be explicitly mentioned: default values when omitted are `page=1` and `perPage=10`.

A `400` response is returned if the arguments have invalid values i.e
- `page <= 0` or `perPage <= 0`
- `page` exceeds the total amount of pages
