### PR TITLE
add ResourceNotFoundException, replace RuntimeExceptions

### DIFF
--- a/src/main/java/com/sarapis/orservice/exception/ResourceNotFoundException.java
+++ b/src/main/java/com/sarapis/orservice/exception/ResourceNotFoundException.java
@@ -1,0 +1,11 @@
+package com.sarapis.orservice.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+public class ResourceNotFoundException extends ResponseStatusException {
+
+    public ResourceNotFoundException(String message) {
+        super(HttpStatus.NOT_FOUND, message);
+    }
+}

--- a/src/main/java/com/sarapis/orservice/service/AccessibilityServiceImpl.java
+++ b/src/main/java/com/sarapis/orservice/service/AccessibilityServiceImpl.java
@@ -3,6 +3,7 @@ package com.sarapis.orservice.service;
 import com.sarapis.orservice.dto.AccessibilityDTO;
 import com.sarapis.orservice.entity.Accessibility;
 import com.sarapis.orservice.entity.core.Location;
+import com.sarapis.orservice.exception.ResourceNotFoundException;
 import com.sarapis.orservice.repository.AccessibilityRepository;
 import com.sarapis.orservice.repository.LocationRepository;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -39,7 +40,7 @@ public class AccessibilityServiceImpl implements AccessibilityService {
     @Override
     public AccessibilityDTO getAccessibilityById(String accessibilityId) {
         Accessibility accessibility = this.accessibilityRepository.findById(accessibilityId)
-                .orElseThrow(() -> new RuntimeException("Accessibility not found."));
+                .orElseThrow(() -> new ResourceNotFoundException("Accessibility not found."));
         AccessibilityDTO accessibilityDTO = accessibility.toDTO();
         this.addRelatedData(accessibilityDTO);
         return accessibilityDTO;
@@ -51,7 +52,7 @@ public class AccessibilityServiceImpl implements AccessibilityService {
 
         if (accessibilityDTO.getLocationId() != null) {
             location = this.locationRepository.findById(accessibilityDTO.getLocationId())
-                    .orElseThrow(() -> new RuntimeException("Location not found."));
+                    .orElseThrow(() -> new ResourceNotFoundException("Location not found."));
         }
 
         Accessibility accessibility = this.accessibilityRepository.save(accessibilityDTO.toEntity(location));
@@ -67,7 +68,7 @@ public class AccessibilityServiceImpl implements AccessibilityService {
     @Override
     public AccessibilityDTO updateAccessibility(String accessibilityId, AccessibilityDTO accessibilityDTO) {
         Accessibility accessibility = this.accessibilityRepository.findById(accessibilityId)
-                .orElseThrow(() -> new RuntimeException("Accessibility not found."));
+                .orElseThrow(() -> new ResourceNotFoundException("Accessibility not found."));
 
         accessibility.setDescription(accessibilityDTO.getDescription());
         accessibility.setDetails(accessibilityDTO.getDetails());
@@ -80,7 +81,7 @@ public class AccessibilityServiceImpl implements AccessibilityService {
     @Override
     public void deleteAccessibility(String accessibilityId) {
         Accessibility accessibility = this.accessibilityRepository.findById(accessibilityId)
-                .orElseThrow(() -> new RuntimeException("Accessibility not found."));
+                .orElseThrow(() -> new ResourceNotFoundException("Accessibility not found."));
         this.attributeService.deleteRelatedAttributes(accessibility.getId());
         this.metadataService.deleteRelatedMetadata(accessibility.getId());
         this.accessibilityRepository.delete(accessibility);

--- a/src/main/java/com/sarapis/orservice/service/AddressServiceImpl.java
+++ b/src/main/java/com/sarapis/orservice/service/AddressServiceImpl.java
@@ -3,6 +3,7 @@ package com.sarapis.orservice.service;
 import com.sarapis.orservice.dto.AddressDTO;
 import com.sarapis.orservice.entity.Address;
 import com.sarapis.orservice.entity.core.Location;
+import com.sarapis.orservice.exception.ResourceNotFoundException;
 import com.sarapis.orservice.repository.AddressRepository;
 import com.sarapis.orservice.repository.LocationRepository;
 import org.springframework.stereotype.Service;
@@ -37,7 +38,7 @@ public class AddressServiceImpl implements AddressService {
     @Override
     public AddressDTO getAddressById(String addressId) {
         Address address = this.addressRepository.findById(addressId)
-                .orElseThrow(() -> new RuntimeException("Address not found."));
+                .orElseThrow(() -> new ResourceNotFoundException("Address not found."));
         AddressDTO addressDTO = address.toDTO();
         this.addRelatedData(addressDTO);
         return addressDTO;
@@ -49,7 +50,7 @@ public class AddressServiceImpl implements AddressService {
 
         if (addressDTO.getLocationId() != null) {
             location = this.locationRepository.findById(addressDTO.getLocationId())
-                    .orElseThrow(() -> new RuntimeException("Location not found."));
+                    .orElseThrow(() -> new ResourceNotFoundException("Location not found."));
         }
 
         Address address = this.addressRepository.save(addressDTO.toEntity(location));
@@ -65,7 +66,7 @@ public class AddressServiceImpl implements AddressService {
     @Override
     public AddressDTO updateAddress(String addressId, AddressDTO addressDTO) {
         Address address = this.addressRepository.findById(addressId)
-                .orElseThrow(() -> new RuntimeException("Address not found."));
+                .orElseThrow(() -> new ResourceNotFoundException("Address not found."));
 
         address.setAttention(addressDTO.getAttention());
         address.setAddress_1(addressDTO.getAddress_1());
@@ -84,7 +85,7 @@ public class AddressServiceImpl implements AddressService {
     @Override
     public void deleteAddress(String addressId) {
         Address address = this.addressRepository.findById(addressId)
-                .orElseThrow(() -> new RuntimeException("Address not found."));
+                .orElseThrow(() -> new ResourceNotFoundException("Address not found."));
         this.attributeService.deleteRelatedAttributes(address.getId());
         this.metadataService.deleteRelatedMetadata(address.getId());
         this.addressRepository.delete(address);

--- a/src/main/java/com/sarapis/orservice/service/AttributeServiceImpl.java
+++ b/src/main/java/com/sarapis/orservice/service/AttributeServiceImpl.java
@@ -2,6 +2,7 @@ package com.sarapis.orservice.service;
 
 import com.sarapis.orservice.dto.AttributeDTO;
 import com.sarapis.orservice.entity.Attribute;
+import com.sarapis.orservice.exception.ResourceNotFoundException;
 import com.sarapis.orservice.repository.AttributeRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -37,7 +38,7 @@ public class AttributeServiceImpl implements AttributeService {
     @Override
     public AttributeDTO getAttributeById(String attributeId) {
         Attribute attribute = this.attributeRepository.findById(attributeId)
-                .orElseThrow(() -> new RuntimeException("Attribute not found."));
+                .orElseThrow(() -> new ResourceNotFoundException("Attribute not found."));
         AttributeDTO attributeDTO = attribute.toDTO();
         this.addRelatedData(attributeDTO);
         return attributeDTO;
@@ -55,7 +56,7 @@ public class AttributeServiceImpl implements AttributeService {
     @Override
     public AttributeDTO updateAttribute(String attributeId, AttributeDTO attributeDTO) {
         Attribute attribute = this.attributeRepository.findById(attributeId)
-                .orElseThrow(() -> new RuntimeException("Attribute not found."));
+                .orElseThrow(() -> new ResourceNotFoundException("Attribute not found."));
 
         attribute.setLinkId(attributeDTO.getLinkId());
         attribute.setLinkType(attributeDTO.getLinkType());
@@ -71,7 +72,7 @@ public class AttributeServiceImpl implements AttributeService {
     @Override
     public void deleteAttribute(String attributeId) {
         Attribute attribute = this.attributeRepository.findById(attributeId)
-                .orElseThrow(() -> new RuntimeException("Attribute not found."));
+                .orElseThrow(() -> new ResourceNotFoundException("Attribute not found."));
         this.metadataService.deleteRelatedMetadata(attribute.getId());
         this.attributeRepository.delete(attribute);
     }

--- a/src/main/java/com/sarapis/orservice/service/ContactServiceImpl.java
+++ b/src/main/java/com/sarapis/orservice/service/ContactServiceImpl.java
@@ -6,6 +6,7 @@ import com.sarapis.orservice.entity.Contact;
 import com.sarapis.orservice.entity.core.Location;
 import com.sarapis.orservice.entity.core.Organization;
 import com.sarapis.orservice.entity.core.ServiceAtLocation;
+import com.sarapis.orservice.exception.ResourceNotFoundException;
 import com.sarapis.orservice.repository.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -49,7 +50,7 @@ public class ContactServiceImpl implements ContactService {
     @Override
     public ContactDTO getContactById(String contactId) {
         Contact contact = this.contactRepository.findById(contactId)
-                .orElseThrow(() -> new RuntimeException("Contact not found."));
+                .orElseThrow(() -> new ResourceNotFoundException("Contact not found."));
         ContactDTO contactDTO = contact.toDTO();
         this.addRelatedData(contactDTO);
         return contactDTO;
@@ -61,7 +62,7 @@ public class ContactServiceImpl implements ContactService {
 
         if (upsertContactDTO.getOrganizationId() != null) {
             Organization organization = this.organizationRepository.findById(upsertContactDTO.getOrganizationId())
-                    .orElseThrow(() -> new RuntimeException("Organization not found."));
+                    .orElseThrow(() -> new ResourceNotFoundException("Organization not found."));
             organization.getContacts().add(createdContact);
             this.organizationRepository.save(organization);
             createdContact.setOrganization(organization);
@@ -69,7 +70,7 @@ public class ContactServiceImpl implements ContactService {
 
         if (upsertContactDTO.getServiceId() != null) {
             com.sarapis.orservice.entity.core.Service service = this.serviceRepository.findById(upsertContactDTO.getServiceId())
-                    .orElseThrow(() -> new RuntimeException("Service not found."));
+                    .orElseThrow(() -> new ResourceNotFoundException("Service not found."));
             service.getContacts().add(createdContact);
             this.serviceRepository.save(service);
             createdContact.setService(service);
@@ -77,7 +78,7 @@ public class ContactServiceImpl implements ContactService {
 
         if (upsertContactDTO.getServiceAtLocationId() != null) {
             ServiceAtLocation serviceAtLocation = this.serviceAtLocationRepository.findById(upsertContactDTO.getServiceAtLocationId())
-                    .orElseThrow(() -> new RuntimeException("Service at location not found."));
+                    .orElseThrow(() -> new ResourceNotFoundException("Service at location not found."));
             serviceAtLocation.getContacts().add(createdContact);
             this.serviceAtLocationRepository.save(serviceAtLocation);
             createdContact.setServiceAtLocation(serviceAtLocation);
@@ -85,7 +86,7 @@ public class ContactServiceImpl implements ContactService {
 
         if (upsertContactDTO.getLocationId() != null) {
             Location location = this.locationRepository.findById(upsertContactDTO.getLocationId())
-                    .orElseThrow(() -> new RuntimeException("Location not found."));
+                    .orElseThrow(() -> new ResourceNotFoundException("Location not found."));
             location.getContacts().add(createdContact);
             this.locationRepository.save(location);
             createdContact.setLocation(location);
@@ -98,7 +99,7 @@ public class ContactServiceImpl implements ContactService {
     @Override
     public ContactDTO updateContact(String contactId, ContactDTO contactDTO) {
         Contact contact = this.contactRepository.findById(contactId)
-                .orElseThrow(() -> new RuntimeException("Contact not found."));
+                .orElseThrow(() -> new ResourceNotFoundException("Contact not found."));
 
         contact.setName(contactDTO.getName());
         contact.setTitle(contactDTO.getTitle());
@@ -112,7 +113,7 @@ public class ContactServiceImpl implements ContactService {
     @Override
     public void deleteContact(String contactId) {
         Contact contact = this.contactRepository.findById(contactId)
-                .orElseThrow(() -> new RuntimeException("Contact not found."));
+                .orElseThrow(() -> new ResourceNotFoundException("Contact not found."));
         this.attributeService.deleteRelatedAttributes(contact.getId());
         this.metadataService.deleteRelatedMetadata(contact.getId());
         this.contactRepository.delete(contact);

--- a/src/main/java/com/sarapis/orservice/service/LanguageServiceImpl.java
+++ b/src/main/java/com/sarapis/orservice/service/LanguageServiceImpl.java
@@ -4,6 +4,7 @@ import com.sarapis.orservice.dto.LanguageDTO;
 import com.sarapis.orservice.entity.Language;
 import com.sarapis.orservice.entity.Phone;
 import com.sarapis.orservice.entity.core.Location;
+import com.sarapis.orservice.exception.ResourceNotFoundException;
 import com.sarapis.orservice.repository.LanguageRepository;
 import com.sarapis.orservice.repository.LocationRepository;
 import com.sarapis.orservice.repository.PhoneRepository;
@@ -45,7 +46,7 @@ public class LanguageServiceImpl implements LanguageService {
     @Override
     public LanguageDTO getLanguageById(String languageId) {
         Language language = this.languageRepository.findById(languageId)
-                .orElseThrow(() -> new RuntimeException("Language not found."));
+                .orElseThrow(() -> new ResourceNotFoundException("Language not found."));
         LanguageDTO languageDTO = language.toDTO();
         this.addRelatedData(languageDTO);
         return languageDTO;
@@ -59,15 +60,15 @@ public class LanguageServiceImpl implements LanguageService {
 
         if (languageDTO.getServiceId() != null) {
             service = this.serviceRepository.findById(languageDTO.getServiceId())
-                    .orElseThrow(() -> new RuntimeException("Service not found."));
+                    .orElseThrow(() -> new ResourceNotFoundException("Service not found."));
         }
         if (languageDTO.getLocationId() != null) {
             location = this.locationRepository.findById(languageDTO.getLocationId())
-                    .orElseThrow(() -> new RuntimeException("Location not found."));
+                    .orElseThrow(() -> new ResourceNotFoundException("Location not found."));
         }
         if (languageDTO.getPhoneId() != null) {
             phone = this.phoneRepository.findById(languageDTO.getPhoneId())
-                    .orElseThrow(() -> new RuntimeException("Phone not found."));
+                    .orElseThrow(() -> new ResourceNotFoundException("Phone not found."));
         }
 
         Language language = this.languageRepository.save(languageDTO.toEntity(service, location, phone));
@@ -82,7 +83,7 @@ public class LanguageServiceImpl implements LanguageService {
     @Override
     public LanguageDTO updateLanguage(String languageId, LanguageDTO languageDTO) {
         Language language = this.languageRepository.findById(languageId)
-                .orElseThrow(() -> new RuntimeException("Language not found."));
+                .orElseThrow(() -> new ResourceNotFoundException("Language not found."));
 
         language.setName(languageDTO.getName());
         language.setCode(languageDTO.getCode());
@@ -95,7 +96,7 @@ public class LanguageServiceImpl implements LanguageService {
     @Override
     public void deleteLanguage(String languageId) {
         Language language = this.languageRepository.findById(languageId)
-                .orElseThrow(() -> new RuntimeException("Language not found."));
+                .orElseThrow(() -> new ResourceNotFoundException("Language not found."));
         this.attributeService.deleteRelatedAttributes(language.getId());
         this.metadataService.deleteRelatedMetadata(language.getId());
         this.languageRepository.delete(language);

--- a/src/main/java/com/sarapis/orservice/service/LocationServiceImpl.java
+++ b/src/main/java/com/sarapis/orservice/service/LocationServiceImpl.java
@@ -5,6 +5,7 @@ import com.sarapis.orservice.dto.upsert.UpsertLocationDTO;
 import com.sarapis.orservice.entity.*;
 import com.sarapis.orservice.entity.core.Location;
 import com.sarapis.orservice.entity.core.Organization;
+import com.sarapis.orservice.exception.ResourceNotFoundException;
 import com.sarapis.orservice.repository.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -59,7 +60,7 @@ public class LocationServiceImpl implements LocationService {
     @Override
     public LocationDTO getLocationById(String locationId) {
         Location location = this.locationRepository.findById(locationId)
-                .orElseThrow(() -> new RuntimeException("Location not found."));
+                .orElseThrow(() -> new ResourceNotFoundException("Location not found."));
         LocationDTO locationDTO = location.toDTO();
         this.addRelatedData(locationDTO);
         return locationDTO;
@@ -71,7 +72,7 @@ public class LocationServiceImpl implements LocationService {
 
         if (upsertLocationDTO.getOrganizationId() != null) {
             Organization organization = this.organizationRepository.findById(upsertLocationDTO.getOrganizationId())
-                    .orElseThrow(() -> new RuntimeException("Organization not found."));
+                    .orElseThrow(() -> new ResourceNotFoundException("Organization not found."));
             organization.getLocations().add(createdLocation);
             this.organizationRepository.save(organization);
             createdLocation.setOrganization(organization);
@@ -80,7 +81,7 @@ public class LocationServiceImpl implements LocationService {
         createdLocation.setLanguages(new ArrayList<>());
         for (String id : upsertLocationDTO.getLanguages()) {
             Language language = this.languageRepository.findById(id)
-                    .orElseThrow(() -> new RuntimeException("Language not found."));
+                    .orElseThrow(() -> new ResourceNotFoundException("Language not found."));
             language.setLocation(createdLocation);
             this.languageRepository.save(language);
             createdLocation.getLanguages().add(language);
@@ -89,7 +90,7 @@ public class LocationServiceImpl implements LocationService {
         createdLocation.setAddresses(new ArrayList<>());
         for (String id : upsertLocationDTO.getAddresses()) {
             Address address = this.addressRepository.findById(id)
-                    .orElseThrow(() -> new RuntimeException("Address not found."));
+                    .orElseThrow(() -> new ResourceNotFoundException("Address not found."));
             address.setLocation(createdLocation);
             this.addressRepository.save(address);
             createdLocation.getAddresses().add(address);
@@ -98,7 +99,7 @@ public class LocationServiceImpl implements LocationService {
         createdLocation.setPhones(new ArrayList<>());
         for (String id  : upsertLocationDTO.getPhones()) {
             Phone phone = this.phoneRepository.findById(id)
-                    .orElseThrow(() -> new RuntimeException("Phone not found."));
+                    .orElseThrow(() -> new ResourceNotFoundException("Phone not found."));
             phone.setLocation(createdLocation);
             this.phoneRepository.save(phone);
             createdLocation.getPhones().add(phone);
@@ -107,7 +108,7 @@ public class LocationServiceImpl implements LocationService {
         createdLocation.setContacts(new ArrayList<>());
         for (String id  : upsertLocationDTO.getContacts()) {
             Contact contact = this.contactRepository.findById(id)
-                    .orElseThrow(() -> new RuntimeException("Contact not found."));
+                    .orElseThrow(() -> new ResourceNotFoundException("Contact not found."));
             contact.setLocation(createdLocation);
             this.contactRepository.save(contact);
             createdLocation.getContacts().add(contact);
@@ -116,7 +117,7 @@ public class LocationServiceImpl implements LocationService {
         createdLocation.setAccessibility(new ArrayList<>());
         for (String id  : upsertLocationDTO.getAccessibility()) {
             Accessibility accessibility = this.accessibilityRepository.findById(id)
-                    .orElseThrow(() -> new RuntimeException("Accessibility not found."));
+                    .orElseThrow(() -> new ResourceNotFoundException("Accessibility not found."));
             accessibility.setLocation(createdLocation);
             this.accessibilityRepository.save(accessibility);
             createdLocation.getAccessibility().add(accessibility);
@@ -125,7 +126,7 @@ public class LocationServiceImpl implements LocationService {
         createdLocation.setSchedules(new ArrayList<>());
         for (String id  : upsertLocationDTO.getSchedules()) {
             Schedule schedule = this.scheduleRepository.findById(id)
-                    .orElseThrow(() -> new RuntimeException("Schedule not found."));
+                    .orElseThrow(() -> new ResourceNotFoundException("Schedule not found."));
             schedule.setLocation(createdLocation);
             this.scheduleRepository.save(schedule);
             createdLocation.getSchedules().add(schedule);
@@ -138,7 +139,7 @@ public class LocationServiceImpl implements LocationService {
     @Override
     public LocationDTO updateLocation(String locationId, LocationDTO locationDTO) {
         Location location = this.locationRepository.findById(locationId)
-                .orElseThrow(() -> new RuntimeException("Location not found."));
+                .orElseThrow(() -> new ResourceNotFoundException("Location not found."));
 
         location.setLocationType(locationDTO.getLocationType());
         location.setUrl(locationDTO.getUrl());
@@ -158,7 +159,7 @@ public class LocationServiceImpl implements LocationService {
     @Override
     public void deleteLocation(String locationId) {
         Location location = this.locationRepository.findById(locationId)
-                .orElseThrow(() -> new RuntimeException("Location not found."));
+                .orElseThrow(() -> new ResourceNotFoundException("Location not found."));
         this.attributeService.deleteRelatedAttributes(location.getId());
         this.metadataService.deleteRelatedMetadata(location.getId());
         this.locationRepository.delete(location);

--- a/src/main/java/com/sarapis/orservice/service/MetadataServiceImpl.java
+++ b/src/main/java/com/sarapis/orservice/service/MetadataServiceImpl.java
@@ -2,6 +2,7 @@ package com.sarapis.orservice.service;
 
 import com.sarapis.orservice.dto.MetadataDTO;
 import com.sarapis.orservice.entity.Metadata;
+import com.sarapis.orservice.exception.ResourceNotFoundException;
 import com.sarapis.orservice.repository.MetadataRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -32,7 +33,7 @@ public class MetadataServiceImpl implements MetadataService {
     @Override
     public MetadataDTO getMetadata(String metadataId) {
         Metadata metadata = this.metadataRepository.findById(metadataId)
-                .orElseThrow(() -> new RuntimeException("Metadata not found."));
+                .orElseThrow(() -> new ResourceNotFoundException("Metadata not found."));
         return metadata.toDTO();
     }
 
@@ -44,7 +45,7 @@ public class MetadataServiceImpl implements MetadataService {
     @Override
     public MetadataDTO updateMetadata(String metadataId, String resourceId, MetadataDTO metadataDTO) {
         Metadata metadata = this.metadataRepository.findById(metadataId)
-                .orElseThrow(() -> new RuntimeException("Metadata not found."));
+                .orElseThrow(() -> new ResourceNotFoundException("Metadata not found."));
 
         metadata.setResourceId(resourceId);
         metadata.setResourceType(metadataDTO.getResourceType());
@@ -61,7 +62,7 @@ public class MetadataServiceImpl implements MetadataService {
     @Override
     public void deleteMetadata(String metadataId) {
         Metadata metadata = this.metadataRepository.findById(metadataId)
-                .orElseThrow(() -> new RuntimeException("Metadata not found."));
+                .orElseThrow(() -> new ResourceNotFoundException("Metadata not found."));
         this.metadataRepository.delete(metadata);
     }
 

--- a/src/main/java/com/sarapis/orservice/service/OrganizationServiceImpl.java
+++ b/src/main/java/com/sarapis/orservice/service/OrganizationServiceImpl.java
@@ -6,6 +6,7 @@ import com.sarapis.orservice.dto.upsert.UpsertOrganizationIdentifierDTO;
 import com.sarapis.orservice.entity.*;
 import com.sarapis.orservice.entity.core.Location;
 import com.sarapis.orservice.entity.core.Organization;
+import com.sarapis.orservice.exception.ResourceNotFoundException;
 import com.sarapis.orservice.repository.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -61,7 +62,7 @@ public class OrganizationServiceImpl implements OrganizationService {
     @Override
     public OrganizationDTO getOrganizationById(String organizationId) {
         Organization organization = this.organizationRepository.findById(organizationId)
-                .orElseThrow(() -> new RuntimeException("Organization not found."));
+                .orElseThrow(() -> new ResourceNotFoundException("Organization not found."));
         OrganizationDTO organizationDTO = organization.toDTO();
         this.addRelatedData(organizationDTO);
         return organizationDTO;
@@ -74,14 +75,14 @@ public class OrganizationServiceImpl implements OrganizationService {
         if (upsertOrganizationDTO.getParentOrganizationId() != null) {
             Organization parentOrganization = this.organizationRepository
                     .findById(upsertOrganizationDTO.getParentOrganizationId())
-                    .orElseThrow(() -> new RuntimeException("Parent organization not found."));
+                    .orElseThrow(() -> new ResourceNotFoundException("Parent organization not found."));
             createdOrganization.setParentOrganization(parentOrganization);
         }
 
         createdOrganization.setAdditionalWebsites(new ArrayList<>());
         for (String id : upsertOrganizationDTO.getAdditionalWebsites()) {
             Url url = this.urlRepository.findById(id)
-                    .orElseThrow(() -> new RuntimeException("Url not found."));
+                    .orElseThrow(() -> new ResourceNotFoundException("Url not found."));
             url.setOrganization(createdOrganization);
             this.urlRepository.save(url);
             createdOrganization.getAdditionalWebsites().add(url);
@@ -90,7 +91,7 @@ public class OrganizationServiceImpl implements OrganizationService {
         createdOrganization.setFunding(new ArrayList<>());
         for (String id : upsertOrganizationDTO.getFundings()) {
             Funding funding = this.fundingRepository.findById(id)
-                    .orElseThrow(() -> new RuntimeException("Funding not found."));
+                    .orElseThrow(() -> new ResourceNotFoundException("Funding not found."));
             funding.setOrganization(createdOrganization);
             this.fundingRepository.save(funding);
             createdOrganization.getFunding().add(funding);
@@ -99,7 +100,7 @@ public class OrganizationServiceImpl implements OrganizationService {
         createdOrganization.setLocations(new ArrayList<>());
         for (String id : upsertOrganizationDTO.getLocations()) {
             Location location = this.locationRepository.findById(id)
-                    .orElseThrow(() -> new RuntimeException("Location not found."));
+                    .orElseThrow(() -> new ResourceNotFoundException("Location not found."));
             location.setOrganization(createdOrganization);
             this.locationRepository.save(location);
             createdOrganization.getLocations().add(location);
@@ -108,7 +109,7 @@ public class OrganizationServiceImpl implements OrganizationService {
         createdOrganization.setPhones(new ArrayList<>());
         for (String id : upsertOrganizationDTO.getPhones()) {
             Phone phone = this.phoneRepository.findById(id)
-                    .orElseThrow(() -> new RuntimeException("Phone not found."));
+                    .orElseThrow(() -> new ResourceNotFoundException("Phone not found."));
             phone.setOrganization(createdOrganization);
             this.phoneRepository.save(phone);
             createdOrganization.getPhones().add(phone);
@@ -117,7 +118,7 @@ public class OrganizationServiceImpl implements OrganizationService {
         createdOrganization.setContacts(new ArrayList<>());
         for (String id : upsertOrganizationDTO.getContacts()) {
             Contact contact = this.contactRepository.findById(id)
-                    .orElseThrow(() -> new RuntimeException("Contact not found."));
+                    .orElseThrow(() -> new ResourceNotFoundException("Contact not found."));
             contact.setOrganization(createdOrganization);
             this.contactRepository.save(contact);
             createdOrganization.getContacts().add(contact);
@@ -126,7 +127,7 @@ public class OrganizationServiceImpl implements OrganizationService {
         createdOrganization.setPrograms(new ArrayList<>());
         for (String id : upsertOrganizationDTO.getPrograms()) {
             Program program = this.programRepository.findById(id)
-                    .orElseThrow(() -> new RuntimeException("Program not found."));
+                    .orElseThrow(() -> new ResourceNotFoundException("Program not found."));
             program.setOrganization(createdOrganization);
             this.programRepository.save(program);
             createdOrganization.getPrograms().add(program);
@@ -147,7 +148,7 @@ public class OrganizationServiceImpl implements OrganizationService {
     @Override
     public OrganizationDTO updateOrganization(String organizationId, OrganizationDTO organizationDTO) {
         Organization organization = this.organizationRepository.findById(organizationId)
-                .orElseThrow(() -> new RuntimeException("Organization not found."));
+                .orElseThrow(() -> new ResourceNotFoundException("Organization not found."));
 
         organization.setName(organizationDTO.getName());
         organization.setAlternateName(organizationDTO.getAlternateName());
@@ -168,7 +169,7 @@ public class OrganizationServiceImpl implements OrganizationService {
     @Override
     public void deleteOrganization(String organizationId) {
         Organization organization = this.organizationRepository.findById(organizationId)
-                .orElseThrow(() -> new RuntimeException("Organization not found."));
+                .orElseThrow(() -> new ResourceNotFoundException("Organization not found."));
         this.attributeService.deleteRelatedAttributes(organization.getId());
         this.metadataService.deleteRelatedMetadata(organization.getId());
         this.organizationRepository.delete(organization);

--- a/src/main/java/com/sarapis/orservice/service/PhoneServiceImpl.java
+++ b/src/main/java/com/sarapis/orservice/service/PhoneServiceImpl.java
@@ -6,6 +6,7 @@ import com.sarapis.orservice.entity.Phone;
 import com.sarapis.orservice.entity.core.Location;
 import com.sarapis.orservice.entity.core.Organization;
 import com.sarapis.orservice.entity.core.ServiceAtLocation;
+import com.sarapis.orservice.exception.ResourceNotFoundException;
 import com.sarapis.orservice.repository.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -53,7 +54,7 @@ public class PhoneServiceImpl implements PhoneService {
     @Override
     public PhoneDTO getPhoneById(String phoneId) {
         Phone phone = this.phoneRepository.findById(phoneId)
-                .orElseThrow(() -> new RuntimeException("Phone not found."));
+                .orElseThrow(() -> new ResourceNotFoundException("Phone not found."));
         PhoneDTO phoneDTO = phone.toDTO();
         this.addRelatedData(phoneDTO);
         return phoneDTO;
@@ -69,23 +70,23 @@ public class PhoneServiceImpl implements PhoneService {
 
         if (phoneDTO.getLocationId() != null) {
             location = this.locationRepository.findById(phoneDTO.getLocationId())
-                    .orElseThrow(() -> new RuntimeException("Location not found."));
+                    .orElseThrow(() -> new ResourceNotFoundException("Location not found."));
         }
         if (phoneDTO.getServiceId() != null) {
             service = this.serviceRepository.findById(phoneDTO.getServiceId())
-                    .orElseThrow(() -> new RuntimeException("Service not found."));
+                    .orElseThrow(() -> new ResourceNotFoundException("Service not found."));
         }
         if (phoneDTO.getOrganizationId() != null) {
             organization = this.organizationRepository.findById(phoneDTO.getOrganizationId())
-                    .orElseThrow(() -> new RuntimeException("Organization not found."));
+                    .orElseThrow(() -> new ResourceNotFoundException("Organization not found."));
         }
         if (phoneDTO.getContactId() != null) {
             contact = this.contactRepository.findById(phoneDTO.getContactId())
-                    .orElseThrow(() -> new RuntimeException("Contact not found."));
+                    .orElseThrow(() -> new ResourceNotFoundException("Contact not found."));
         }
         if (phoneDTO.getServiceAtLocationId() != null) {
             serviceAtLocation = this.serviceAtLocationRepository.findById(phoneDTO.getServiceAtLocationId())
-                    .orElseThrow(() -> new RuntimeException("Service at location not found."));
+                    .orElseThrow(() -> new ResourceNotFoundException("Service at location not found."));
         }
 
         Phone phone = this.phoneRepository.save(phoneDTO.toEntity(location, service, organization, contact, serviceAtLocation));
@@ -99,7 +100,7 @@ public class PhoneServiceImpl implements PhoneService {
 
     @Override
     public PhoneDTO updatePhone(String phoneId, PhoneDTO phoneDTO) {
-        Phone oldPhone = this.phoneRepository.findById(phoneId).orElseThrow(() -> new RuntimeException("Phone not found."));
+        Phone oldPhone = this.phoneRepository.findById(phoneId).orElseThrow(() -> new ResourceNotFoundException("Phone not found."));
 
         oldPhone.setNumber(phoneDTO.getNumber());
         oldPhone.setExtension(phoneDTO.getExtension());
@@ -112,7 +113,8 @@ public class PhoneServiceImpl implements PhoneService {
 
     @Override
     public void deletePhone(String phoneId) {
-        Phone phone = this.phoneRepository.findById(phoneId).orElseThrow(() -> new RuntimeException("Phone not found."));
+        Phone phone = this.phoneRepository.findById(phoneId)
+                .orElseThrow(() -> new ResourceNotFoundException("Phone not found."));
         this.attributeService.deleteRelatedAttributes(phone.getId());
         this.metadataService.deleteRelatedMetadata(phone.getId());
         this.phoneRepository.delete(phone);

--- a/src/main/java/com/sarapis/orservice/service/ProgramServiceImpl.java
+++ b/src/main/java/com/sarapis/orservice/service/ProgramServiceImpl.java
@@ -4,6 +4,7 @@ import com.sarapis.orservice.dto.ProgramDTO;
 import com.sarapis.orservice.dto.upsert.UpsertProgramDTO;
 import com.sarapis.orservice.entity.Program;
 import com.sarapis.orservice.entity.core.Organization;
+import com.sarapis.orservice.exception.ResourceNotFoundException;
 import com.sarapis.orservice.repository.OrganizationRepository;
 import com.sarapis.orservice.repository.ProgramRepository;
 import org.springframework.stereotype.Service;
@@ -38,7 +39,7 @@ public class ProgramServiceImpl implements ProgramService {
     @Override
     public ProgramDTO getProgramDTOById(String programId) {
         Program program = this.programRepository.findById(programId)
-                .orElseThrow(() -> new RuntimeException("Program not found."));
+                .orElseThrow(() -> new ResourceNotFoundException("Program not found."));
         ProgramDTO programDTO = program.toDTO();
         this.addRelatedData(programDTO);
         return programDTO;
@@ -49,7 +50,7 @@ public class ProgramServiceImpl implements ProgramService {
         Program program = upsertProgramDTO.create();
 
         Organization organization = this.organizationRepository.findById(upsertProgramDTO.getOrganizationId())
-                .orElseThrow(() -> new RuntimeException("Organization not found."));
+                .orElseThrow(() -> new ResourceNotFoundException("Organization not found."));
         program.setOrganization(organization);
 
         Program createdProgram = this.programRepository.save(program);
@@ -61,7 +62,7 @@ public class ProgramServiceImpl implements ProgramService {
     @Override
     public ProgramDTO updateProgram(String programId, ProgramDTO programDTO) {
         Program program = this.programRepository.findById(programId)
-                .orElseThrow(() -> new RuntimeException("Program not found."));
+                .orElseThrow(() -> new ResourceNotFoundException("Program not found."));
 
         program.setId(programDTO.getId());
         program.setName(programDTO.getName());
@@ -75,7 +76,7 @@ public class ProgramServiceImpl implements ProgramService {
     @Override
     public void deleteProgram(String programId) {
         Program program = this.programRepository.findById(programId)
-                .orElseThrow(() -> new RuntimeException("Program not found."));
+                .orElseThrow(() -> new ResourceNotFoundException("Program not found."));
         this.attributeService.deleteRelatedAttributes(program.getId());
         this.metadataService.deleteRelatedMetadata(program.getId());
         this.programRepository.delete(program);

--- a/src/main/java/com/sarapis/orservice/service/ScheduleServiceImpl.java
+++ b/src/main/java/com/sarapis/orservice/service/ScheduleServiceImpl.java
@@ -4,6 +4,7 @@ import com.sarapis.orservice.dto.ScheduleDTO;
 import com.sarapis.orservice.entity.Schedule;
 import com.sarapis.orservice.entity.core.Location;
 import com.sarapis.orservice.entity.core.ServiceAtLocation;
+import com.sarapis.orservice.exception.ResourceNotFoundException;
 import com.sarapis.orservice.repository.LocationRepository;
 import com.sarapis.orservice.repository.ScheduleRepository;
 import com.sarapis.orservice.repository.ServiceAtLocationRepository;
@@ -45,7 +46,7 @@ public class ScheduleServiceImpl implements ScheduleService {
     @Override
     public ScheduleDTO getScheduleById(String scheduleId) {
         Schedule schedule = this.scheduleRepository.findById(scheduleId)
-                .orElseThrow(() -> new RuntimeException("Schedule not found."));
+                .orElseThrow(() -> new ResourceNotFoundException("Schedule not found."));
         ScheduleDTO scheduleDTO = schedule.toDTO();
         this.addRelatedData(scheduleDTO);
         return scheduleDTO;
@@ -59,15 +60,15 @@ public class ScheduleServiceImpl implements ScheduleService {
 
         if (scheduleDTO.getServiceId() != null) {
             service = this.serviceRepository.findById(scheduleDTO.getServiceId())
-                    .orElseThrow(() -> new RuntimeException("Service not found."));
+                    .orElseThrow(() -> new ResourceNotFoundException("Service not found."));
         }
         if (scheduleDTO.getLocationId() != null) {
             location = this.locationRepository.findById(scheduleDTO.getLocationId())
-                    .orElseThrow(() -> new RuntimeException("Location not found."));
+                    .orElseThrow(() -> new ResourceNotFoundException("Location not found."));
         }
         if (scheduleDTO.getServiceAtLocationId() != null) {
             serviceAtLocation = this.serviceAtLocationRepository.findById(scheduleDTO.getServiceAtLocationId())
-                    .orElseThrow(() -> new RuntimeException("Service at location not found."));
+                    .orElseThrow(() -> new ResourceNotFoundException("Service at location not found."));
         }
 
         Schedule schedule = this.scheduleRepository.save(scheduleDTO.toEntity(service, location, serviceAtLocation));
@@ -82,7 +83,7 @@ public class ScheduleServiceImpl implements ScheduleService {
     @Override
     public ScheduleDTO updateSchedule(String scheduleId, ScheduleDTO scheduleDTO) {
         Schedule schedule = this.scheduleRepository.findById(scheduleId)
-                .orElseThrow(() -> new RuntimeException("Schedule not found."));
+                .orElseThrow(() -> new ResourceNotFoundException("Schedule not found."));
 
         schedule.setValidFrom(scheduleDTO.getValidFrom());
         schedule.setValidTo(scheduleDTO.getValidTo());
@@ -111,7 +112,7 @@ public class ScheduleServiceImpl implements ScheduleService {
     @Override
     public void deleteSchedule(String scheduleId) {
         Schedule schedule = this.scheduleRepository.findById(scheduleId)
-                .orElseThrow(() -> new RuntimeException("Schedule not found."));
+                .orElseThrow(() -> new ResourceNotFoundException("Schedule not found."));
         this.attributeService.deleteRelatedAttributes(schedule.getId());
         this.metadataService.deleteRelatedMetadata(schedule.getId());
         this.scheduleRepository.delete(schedule);

--- a/src/main/java/com/sarapis/orservice/service/ServiceAreaServiceImpl.java
+++ b/src/main/java/com/sarapis/orservice/service/ServiceAreaServiceImpl.java
@@ -3,6 +3,7 @@ package com.sarapis.orservice.service;
 import com.sarapis.orservice.dto.ServiceAreaDTO;
 import com.sarapis.orservice.entity.ServiceArea;
 import com.sarapis.orservice.entity.core.ServiceAtLocation;
+import com.sarapis.orservice.exception.ResourceNotFoundException;
 import com.sarapis.orservice.repository.ServiceAreaRepository;
 import com.sarapis.orservice.repository.ServiceAtLocationRepository;
 import com.sarapis.orservice.repository.ServiceRepository;
@@ -43,7 +44,7 @@ public class ServiceAreaServiceImpl implements ServiceAreaService {
     @Override
     public ServiceAreaDTO getServiceAreaById(String serviceAreaId) {
         ServiceArea serviceArea = this.serviceAreaRepository.findById(serviceAreaId)
-                .orElseThrow(() -> new RuntimeException("Service area not found."));
+                .orElseThrow(() -> new ResourceNotFoundException("Service area not found."));
         ServiceAreaDTO serviceAreaDTO = serviceArea.toDTO();
         this.addRelatedData(serviceAreaDTO);
         return serviceAreaDTO;
@@ -56,11 +57,11 @@ public class ServiceAreaServiceImpl implements ServiceAreaService {
 
         if (serviceAreaDTO.getServiceId() != null) {
             service = this.serviceRepository.findById(serviceAreaDTO.getServiceId())
-                    .orElseThrow(() -> new RuntimeException("Service not found."));
+                    .orElseThrow(() -> new ResourceNotFoundException("Service not found."));
         }
         if (serviceAreaDTO.getServiceAtLocationId() != null) {
             serviceAtLocation = this.serviceAtLocationRepository.findById(serviceAreaDTO.getServiceAtLocationId())
-                    .orElseThrow(() -> new RuntimeException("Service atlocation not found."));
+                    .orElseThrow(() -> new ResourceNotFoundException("Service atlocation not found."));
         }
 
         ServiceArea serviceArea = this.serviceAreaRepository.save(serviceAreaDTO.toEntity(service, serviceAtLocation));
@@ -75,7 +76,7 @@ public class ServiceAreaServiceImpl implements ServiceAreaService {
     @Override
     public ServiceAreaDTO updateServiceArea(String serviceAreaId, ServiceAreaDTO serviceAreaDTO) {
         ServiceArea serviceArea = this.serviceAreaRepository.findById(serviceAreaId)
-                .orElseThrow(() -> new RuntimeException("ServiceArea not found"));
+                .orElseThrow(() -> new ResourceNotFoundException("ServiceArea not found"));
 
         serviceArea.setId(serviceAreaDTO.getId());
         serviceArea.setName(serviceAreaDTO.getName());
@@ -91,7 +92,7 @@ public class ServiceAreaServiceImpl implements ServiceAreaService {
     @Override
     public void deleteServiceArea(String serviceAreaId) {
         ServiceArea serviceArea = this.serviceAreaRepository.findById(serviceAreaId)
-                .orElseThrow(() -> new RuntimeException("ServiceArea not found"));
+                .orElseThrow(() -> new ResourceNotFoundException("ServiceArea not found"));
         this.attributeService.deleteRelatedAttributes(serviceArea.getId());
         this.metadataService.deleteRelatedMetadata(serviceArea.getId());
         this.serviceAreaRepository.delete(serviceArea);

--- a/src/main/java/com/sarapis/orservice/service/ServiceAtLocationServiceImpl.java
+++ b/src/main/java/com/sarapis/orservice/service/ServiceAtLocationServiceImpl.java
@@ -4,6 +4,7 @@ import com.sarapis.orservice.dto.ServiceAtLocationDTO;
 import com.sarapis.orservice.dto.upsert.UpsertServiceAtLocationDTO;
 import com.sarapis.orservice.entity.core.Location;
 import com.sarapis.orservice.entity.core.ServiceAtLocation;
+import com.sarapis.orservice.exception.ResourceNotFoundException;
 import com.sarapis.orservice.repository.LocationRepository;
 import com.sarapis.orservice.repository.ServiceAtLocationRepository;
 import com.sarapis.orservice.repository.ServiceRepository;
@@ -44,7 +45,7 @@ public class ServiceAtLocationServiceImpl implements ServiceAtLocationService {
     @Override
     public ServiceAtLocationDTO getServiceAtLocationById(String serviceAtLocationId) {
         ServiceAtLocation serviceAtLocation = this.serviceAtLocationRepository.findById(serviceAtLocationId)
-                .orElseThrow(() -> new RuntimeException("Service at location not found."));
+                .orElseThrow(() -> new ResourceNotFoundException("Service at location not found."));
         ServiceAtLocationDTO servLocDTO = serviceAtLocation.toDTO();
         this.addRelatedData(servLocDTO);
         return servLocDTO;
@@ -55,11 +56,11 @@ public class ServiceAtLocationServiceImpl implements ServiceAtLocationService {
         ServiceAtLocation serviceAtLocation = upsertServiceAtLocationDTO.create();
 
         com.sarapis.orservice.entity.core.Service service = this.serviceRepository.findById(upsertServiceAtLocationDTO.getServiceId())
-                .orElseThrow(() -> new RuntimeException("Service not found."));
+                .orElseThrow(() -> new ResourceNotFoundException("Service not found."));
         serviceAtLocation.setService(service);
 
         Location location = this.locationRepository.findById(upsertServiceAtLocationDTO.getLocationId())
-                .orElseThrow(() -> new RuntimeException("Location not found."));
+                .orElseThrow(() -> new ResourceNotFoundException("Location not found."));
         serviceAtLocation.setLocation(location);
 
         ServiceAtLocation createdServiceAtLocation = this.serviceAtLocationRepository.save(serviceAtLocation);
@@ -73,7 +74,7 @@ public class ServiceAtLocationServiceImpl implements ServiceAtLocationService {
     @Override
     public ServiceAtLocationDTO updateServiceAtLocation(String serviceAtLocationId, ServiceAtLocationDTO serviceAtLocationDTO) {
         ServiceAtLocation serviceAtLocation = this.serviceAtLocationRepository.findById(serviceAtLocationId)
-                .orElseThrow(() -> new RuntimeException("Service At Location not found"));
+                .orElseThrow(() -> new ResourceNotFoundException("Service At Location not found"));
 
         serviceAtLocation.setDescription(serviceAtLocationDTO.getDescription());
 
@@ -84,7 +85,7 @@ public class ServiceAtLocationServiceImpl implements ServiceAtLocationService {
     @Override
     public void deleteServiceAtLocation(String serviceAtLocationId) {
         ServiceAtLocation serviceAtLocation = this.serviceAtLocationRepository.findById(serviceAtLocationId)
-                .orElseThrow(() -> new RuntimeException("Service At Location not found."));
+                .orElseThrow(() -> new ResourceNotFoundException("Service At Location not found."));
         this.attributeService.deleteAttribute(serviceAtLocation.getId());
         this.metadataService.deleteMetadata(serviceAtLocation.getId());
         this.serviceAtLocationRepository.delete(serviceAtLocation);

--- a/src/main/java/com/sarapis/orservice/service/ServiceServiceImpl.java
+++ b/src/main/java/com/sarapis/orservice/service/ServiceServiceImpl.java
@@ -9,6 +9,7 @@ import com.sarapis.orservice.entity.*;
 import com.sarapis.orservice.entity.core.Location;
 import com.sarapis.orservice.entity.core.Organization;
 import com.sarapis.orservice.entity.core.ServiceAtLocation;
+import com.sarapis.orservice.exception.ResourceNotFoundException;
 import com.sarapis.orservice.repository.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -88,7 +89,7 @@ public class ServiceServiceImpl implements ServiceService {
     @Override
     public ServiceDTO getServiceById(String serviceId) {
         com.sarapis.orservice.entity.core.Service service = this.serviceRepository.findById(serviceId)
-                .orElseThrow(() -> new RuntimeException("Service not found."));
+                .orElseThrow(() -> new ResourceNotFoundException("Service not found."));
         ServiceDTO serviceDTO = service.toDTO();
         this.addRelatedData(serviceDTO);
         return serviceDTO;
@@ -99,7 +100,7 @@ public class ServiceServiceImpl implements ServiceService {
         com.sarapis.orservice.entity.core.Service service = upsertServiceDTO.create();
 
         Organization organization = this.organizationRepository.findById(upsertServiceDTO.getOrganizationId())
-                .orElseThrow(() -> new RuntimeException("Organization not found."));
+                .orElseThrow(() -> new ResourceNotFoundException("Organization not found."));
         service.setOrganization(organization);
 
         com.sarapis.orservice.entity.core.Service createdService = this.serviceRepository.save(service);
@@ -107,7 +108,7 @@ public class ServiceServiceImpl implements ServiceService {
         createdService.setAdditionalUrls(new ArrayList<>());
         for (String id : upsertServiceDTO.getAdditionalUrls()) {
             Url url = this.urlRepository.findById(id)
-                    .orElseThrow(() -> new RuntimeException("Url not found."));
+                    .orElseThrow(() -> new ResourceNotFoundException("Url not found."));
             url.setOrganization(organization);
             this.urlRepository.save(url);
             createdService.getAdditionalUrls().add(url);
@@ -116,7 +117,7 @@ public class ServiceServiceImpl implements ServiceService {
         createdService.setLanguages(new ArrayList<>());
         for (String id : upsertServiceDTO.getLanguages()) {
             Language language = this.languageRepository.findById(id)
-                    .orElseThrow(() -> new RuntimeException("Language not found."));
+                    .orElseThrow(() -> new ResourceNotFoundException("Language not found."));
             language.setService(createdService);
             this.languageRepository.save(language);
             createdService.getLanguages().add(language);
@@ -125,7 +126,7 @@ public class ServiceServiceImpl implements ServiceService {
         createdService.setFunding(new ArrayList<>());
         for (String id : upsertServiceDTO.getFundings()) {
             Funding funding = this.fundingRepository.findById(id)
-                    .orElseThrow(() -> new RuntimeException("Funding not found."));
+                    .orElseThrow(() -> new ResourceNotFoundException("Funding not found."));
             funding.setService(createdService);
             this.fundingRepository.save(funding);
             createdService.getFunding().add(funding);
@@ -133,7 +134,7 @@ public class ServiceServiceImpl implements ServiceService {
 
         if (upsertServiceDTO.getProgramId() != null) {
             Program program = this.programRepository.findById(upsertServiceDTO.getProgramId())
-                    .orElseThrow(() -> new RuntimeException("Program not found."));
+                    .orElseThrow(() -> new ResourceNotFoundException("Program not found."));
             program.getServices().add(createdService);
             this.programRepository.save(program);
             createdService.setProgram(program);
@@ -142,7 +143,7 @@ public class ServiceServiceImpl implements ServiceService {
         createdService.setRequiredDocuments(new ArrayList<>());
         for (String id : upsertServiceDTO.getRequiredDocuments()) {
             RequiredDocument requiredDocument = this.requiredDocumentRepository.findById(id)
-                    .orElseThrow(() -> new RuntimeException("Required document not found."));
+                    .orElseThrow(() -> new ResourceNotFoundException("Required document not found."));
             requiredDocument.setService(createdService);
             this.requiredDocumentRepository.save(requiredDocument);
             createdService.getRequiredDocuments().add(requiredDocument);
@@ -151,7 +152,7 @@ public class ServiceServiceImpl implements ServiceService {
         createdService.setServiceAtLocations(new ArrayList<>());
         for (String id : upsertServiceDTO.getLocations()) {
             Location location = this.locationRepository.findById(id)
-                    .orElseThrow(() -> new RuntimeException("Location not found."));
+                    .orElseThrow(() -> new ResourceNotFoundException("Location not found."));
             ServiceAtLocation serviceAtLocation = UpsertServiceAtLocationDTO.create(createdService, location);
             ServiceAtLocation createdServiceAtLocation = this.serviceAtLocationRepository.save(serviceAtLocation);
             location.getServiceAtLocations().add(createdServiceAtLocation);
@@ -162,7 +163,7 @@ public class ServiceServiceImpl implements ServiceService {
         createdService.setPhones(new ArrayList<>());
         for (String id : upsertServiceDTO.getPhones()) {
             Phone phone = this.phoneRepository.findById(id)
-                    .orElseThrow(() -> new RuntimeException("Phone not found."));
+                    .orElseThrow(() -> new ResourceNotFoundException("Phone not found."));
             phone.setService(createdService);
             this.phoneRepository.save(phone);
             createdService.getPhones().add(phone);
@@ -171,7 +172,7 @@ public class ServiceServiceImpl implements ServiceService {
         createdService.setContacts(new ArrayList<>());
         for (String id : upsertServiceDTO.getContacts()) {
             Contact contact = this.contactRepository.findById(id)
-                    .orElseThrow(() -> new RuntimeException("Contact not found."));
+                    .orElseThrow(() -> new ResourceNotFoundException("Contact not found."));
             contact.setService(createdService);
             this.contactRepository.save(contact);
             createdService.getContacts().add(contact);
@@ -180,7 +181,7 @@ public class ServiceServiceImpl implements ServiceService {
         createdService.setSchedules(new ArrayList<>());
         for (String id : upsertServiceDTO.getSchedules()) {
             Schedule schedule = this.scheduleRepository.findById(id)
-                    .orElseThrow(() -> new RuntimeException("Schedule not found."));
+                    .orElseThrow(() -> new ResourceNotFoundException("Schedule not found."));
             schedule.setService(createdService);
             this.scheduleRepository.save(schedule);
             createdService.getSchedules().add(schedule);
@@ -189,7 +190,7 @@ public class ServiceServiceImpl implements ServiceService {
         createdService.setServiceAreas(new ArrayList<>());
         for (String id : upsertServiceDTO.getServiceAreas()) {
             ServiceArea serviceArea = this.serviceAreaRepository.findById(id)
-                    .orElseThrow(() -> new RuntimeException("Service area not found."));
+                    .orElseThrow(() -> new ResourceNotFoundException("Service area not found."));
             serviceArea.setService(createdService);
             this.serviceAreaRepository.save(serviceArea);
             createdService.getServiceAreas().add(serviceArea);
@@ -206,7 +207,7 @@ public class ServiceServiceImpl implements ServiceService {
         createdService.setCapacities(new ArrayList<>());
         for (UpsertServiceCapacityDTO dto : upsertServiceDTO.getServiceCapacities()) {
             Unit unit = this.unitRepository.findById(dto.getUnitId())
-                    .orElseThrow(() -> new RuntimeException("Unit not found."));
+                    .orElseThrow(() -> new ResourceNotFoundException("Unit not found."));
             ServiceCapacity serviceCapacity = dto.create();
             serviceCapacity.setService(createdService);
             serviceCapacity.setUnit(unit);
@@ -223,7 +224,7 @@ public class ServiceServiceImpl implements ServiceService {
     @Override
     public ServiceDTO updateService(String serviceId, ServiceDTO serviceDTO) {
         com.sarapis.orservice.entity.core.Service service = this.serviceRepository.findById(serviceId)
-                .orElseThrow(() -> new RuntimeException("Service not found."));
+                .orElseThrow(() -> new ResourceNotFoundException("Service not found."));
 
         com.sarapis.orservice.entity.core.Service updatedService = this.serviceRepository.save(service);
         return this.getServiceById(updatedService.getId());
@@ -232,7 +233,7 @@ public class ServiceServiceImpl implements ServiceService {
     @Override
     public void deleteService(String serviceId) {
         com.sarapis.orservice.entity.core.Service service = this.serviceRepository.findById(serviceId)
-                .orElseThrow(() -> new RuntimeException("Service not found."));
+                .orElseThrow(() -> new ResourceNotFoundException("Service not found."));
         this.attributeService.deleteRelatedAttributes(service.getId());
         this.metadataService.deleteRelatedMetadata(service.getId());
         this.serviceRepository.delete(service);

--- a/src/main/java/com/sarapis/orservice/service/TaxonomyServiceImpl.java
+++ b/src/main/java/com/sarapis/orservice/service/TaxonomyServiceImpl.java
@@ -2,6 +2,7 @@ package com.sarapis.orservice.service;
 
 import com.sarapis.orservice.dto.TaxonomyDTO;
 import com.sarapis.orservice.entity.Taxonomy;
+import com.sarapis.orservice.exception.ResourceNotFoundException;
 import com.sarapis.orservice.repository.TaxonomyRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -30,7 +31,7 @@ public class TaxonomyServiceImpl implements TaxonomyService {
     @Override
     public TaxonomyDTO getTaxonomyById(String taxonomyId) {
         Taxonomy taxonomy = this.taxonomyRepository.findById(taxonomyId)
-                .orElseThrow(() -> new RuntimeException("Taxonomy not found."));
+                .orElseThrow(() -> new ResourceNotFoundException("Taxonomy not found."));
         TaxonomyDTO taxonomyDTO = taxonomy.toDTO();
         this.addRelatedData(taxonomyDTO);
         return taxonomyDTO;
@@ -48,7 +49,7 @@ public class TaxonomyServiceImpl implements TaxonomyService {
     @Override
     public TaxonomyDTO updateTaxonomy(String taxonomyId, TaxonomyDTO taxonomyDTO) {
         Taxonomy taxonomy = this.taxonomyRepository.findById(taxonomyId)
-                .orElseThrow(() -> new RuntimeException("Taxonomy not found."));
+                .orElseThrow(() -> new ResourceNotFoundException("Taxonomy not found."));
 
         taxonomy.setName(taxonomyDTO.getName());
         taxonomy.setDescription(taxonomyDTO.getDescription());
@@ -62,7 +63,7 @@ public class TaxonomyServiceImpl implements TaxonomyService {
     @Override
     public void deleteTaxonomy(String taxonomyId) {
         Taxonomy taxonomy = this.taxonomyRepository.findById(taxonomyId)
-                .orElseThrow(() -> new RuntimeException("Taxonomy not found."));
+                .orElseThrow(() -> new ResourceNotFoundException("Taxonomy not found."));
         this.metadataService.deleteRelatedMetadata(taxonomy.getId());
         this.taxonomyRepository.delete(taxonomy);
     }

--- a/src/main/java/com/sarapis/orservice/service/TaxonomyTermServiceImpl.java
+++ b/src/main/java/com/sarapis/orservice/service/TaxonomyTermServiceImpl.java
@@ -2,6 +2,7 @@ package com.sarapis.orservice.service;
 
 import com.sarapis.orservice.dto.TaxonomyTermDTO;
 import com.sarapis.orservice.entity.TaxonomyTerm;
+import com.sarapis.orservice.exception.ResourceNotFoundException;
 import com.sarapis.orservice.repository.TaxonomyTermRepository;
 import java.util.List;
 
@@ -31,7 +32,7 @@ public class TaxonomyTermServiceImpl implements TaxonomyTermService {
     @Override
     public TaxonomyTermDTO getTaxonomyTermById(String taxonomyTermId) {
         TaxonomyTerm taxonomyTerm = this.taxonomyTermRepository.findById(taxonomyTermId)
-                .orElseThrow(() -> new RuntimeException("Taxonomy term not found."));
+                .orElseThrow(() -> new ResourceNotFoundException("Taxonomy term not found."));
         TaxonomyTermDTO taxonomyTermDTO = taxonomyTerm.toDTO();
         this.addRelatedData(taxonomyTermDTO);
         return taxonomyTermDTO;
@@ -43,7 +44,7 @@ public class TaxonomyTermServiceImpl implements TaxonomyTermService {
 
         if (taxonomyTermDTO.getParentId() != null) {
             parent = this.taxonomyTermRepository.findById(taxonomyTermDTO.getParentId())
-                    .orElseThrow(() -> new RuntimeException("Taxonomy term not found."));
+                    .orElseThrow(() -> new ResourceNotFoundException("Taxonomy term not found."));
         }
 
         TaxonomyTerm taxonomyTerm = taxonomyTermDTO.toEntity(parent);
@@ -56,7 +57,7 @@ public class TaxonomyTermServiceImpl implements TaxonomyTermService {
     @Override
     public TaxonomyTermDTO updateTaxonomyTerm(String taxonomyTermId, TaxonomyTermDTO taxonomyTermDTO) {
         TaxonomyTerm taxonomyTerm = this.taxonomyTermRepository.findById(taxonomyTermId)
-                .orElseThrow(() -> new RuntimeException("Taxonomy term not found."));
+                .orElseThrow(() -> new ResourceNotFoundException("Taxonomy term not found."));
 
         taxonomyTerm.setCode(taxonomyTermDTO.getCode());
         taxonomyTerm.setName(taxonomyTermDTO.getName());
@@ -72,7 +73,7 @@ public class TaxonomyTermServiceImpl implements TaxonomyTermService {
     @Override
     public void deleteTaxonomyTerm(String taxonomyTermId) {
         TaxonomyTerm taxonomyTerm = this.taxonomyTermRepository.findById(taxonomyTermId)
-                .orElseThrow(() -> new RuntimeException("Taxonomy term not found."));
+                .orElseThrow(() -> new ResourceNotFoundException("Taxonomy term not found."));
         this.metadataService.deleteRelatedMetadata(taxonomyTerm.getId());
         this.taxonomyTermRepository.delete(taxonomyTerm);
     }


### PR DESCRIPTION
Instead of throwing bare RuntimeExceptions when a data object is not found (which throws an error with HTTP status 500), we want to throw a 404 Error. This can be done using Spring's [ResponseStatusException ](https://www.baeldung.com/spring-response-status-exception) object, which I extended into a custom ResourceNotFoundException.