### PR TITLE
Support for dynamic origins in prod env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=postgres
 POSTGRES_DB=orservice_db
+FRONTEND_URLS=http://path/to/service

--- a/src/main/java/com/sarapis/orservice/config/SecurityConfig.java
+++ b/src/main/java/com/sarapis/orservice/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.sarapis.orservice.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
@@ -11,13 +12,29 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
+import java.util.Arrays;
 import java.util.List;
 
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig {
     private static final List<String> ALLOWED_ORIGINS_DEV = List.of("http://localhost:5173/");
-    private static final List<String> ALLOWED_ORIGINS_PROD = List.of("http://ec2-34-229-138-80.compute-1.amazonaws.com/");
+    private static List<String> ALLOWED_ORIGINS_PROD;
+
+    // Refer to https://www.baeldung.com/spring-inject-static-field
+    @Value("${prod.allowed_origins:#{null}}")
+    private void setAllowedOriginsProd(String rawUrls) {
+        // So that app won't crash in dev env
+        // Ensure that FRONTEND_URLS is defined in .env for prod
+        if(rawUrls == null)
+            return;
+        String[] urls = rawUrls.split(",");
+        ALLOWED_ORIGINS_PROD = List.copyOf(
+            Arrays.stream(urls)
+                .map(String::trim)
+                .toList()
+        );
+    }
 
     @Bean
     @Profile("prod")

--- a/src/main/java/com/sarapis/orservice/config/SecurityConfig.java
+++ b/src/main/java/com/sarapis/orservice/config/SecurityConfig.java
@@ -13,7 +13,10 @@ import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Configuration
 @EnableWebSecurity
@@ -24,16 +27,11 @@ public class SecurityConfig {
     // Refer to https://www.baeldung.com/spring-inject-static-field
     @Value("${prod.allowed_origins:#{null}}")
     private void setAllowedOriginsProd(String rawUrls) {
-        // So that app won't crash in dev env
-        // Ensure that FRONTEND_URLS is defined in .env for prod
-        if(rawUrls == null)
-            return;
-        String[] urls = rawUrls.split(",");
-        ALLOWED_ORIGINS_PROD = List.copyOf(
-            Arrays.stream(urls)
-                .map(String::trim)
-                .toList()
-        );
+        ALLOWED_ORIGINS_PROD = Optional.ofNullable(rawUrls)
+                .map(urls -> Arrays.stream(urls.split(","))
+                        .map(String::trim)
+                        .collect(Collectors.toUnmodifiableList()))
+                .orElse(Collections.emptyList());
     }
 
     @Bean

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -1,3 +1,5 @@
 app.environment=prod
 server.port=8080
 spring.datasource.url=jdbc:postgresql://orservice_db:5432/orservice_db
+spring.config.import=file:.env[.properties]
+prod.allowed_origins=${FRONTEND_URLS:#{null}}

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -2,4 +2,4 @@ app.environment=prod
 server.port=8080
 spring.datasource.url=jdbc:postgresql://orservice_db:5432/orservice_db
 spring.config.import=file:.env[.properties]
-prod.allowed_origins=${FRONTEND_URLS:#{null}}
+prod.allowed_origins=${FRONTEND_URLS:#{""}}


### PR DESCRIPTION
Allows for `SecurityConfig` to recognize urls listed in the `FRONTEND_URLS` field from `.env` when the application is on the production profile.

Multiple urls must be comma separated, so `FRONTEND_URLS=path1,path2,...`.