### PR TITLE
Feat/linter

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,6 +12,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
@@ -24,6 +26,9 @@ jobs:
           maven-version: '3.8.6'
       - name: Run Spotbugs
         run: mvn -B verify spotbugs:check
+      - uses: jwgmeligmeyling/spotbugs-github-action@master
+        with:
+          path: '**/spotbugsXml.xml'
 
   checkstyle-check:
     runs-on: ubuntu-latest
@@ -31,6 +36,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
@@ -43,3 +50,6 @@ jobs:
           maven-version: '3.8.6'
       - name: Run Checkstyle
         run: mvn -B verify checkstyle:check
+      - uses: jwgmeligmeyling/checkstyle-github-action@master
+        with:
+          path: '**/checkstyle-result.xml'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,6 +27,7 @@ jobs:
       - name: Run Spotbugs
         run: mvn -B verify spotbugs:check
       - uses: jwgmeligmeyling/spotbugs-github-action@master
+        if: failure()
         with:
           path: '**/spotbugsXml.xml'
 
@@ -51,5 +52,6 @@ jobs:
       - name: Run Checkstyle
         run: mvn -B verify checkstyle:check
       - uses: jwgmeligmeyling/checkstyle-github-action@master
+        if: failure()
         with:
           path: '**/checkstyle-result.xml'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      checks: write
     steps:
       - uses: actions/checkout@v3
         with:
@@ -26,7 +27,8 @@ jobs:
           maven-version: '3.8.6'
       - name: Run Spotbugs
         run: mvn -B verify spotbugs:check
-      - uses: jwgmeligmeyling/spotbugs-github-action@master
+      - name: Write Spotbugs Report
+        uses: jwgmeligmeyling/spotbugs-github-action@master
         if: failure()
         with:
           path: '**/spotbugsXml.xml'
@@ -35,6 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      checks: write
     steps:
       - uses: actions/checkout@v3
         with:
@@ -51,7 +54,8 @@ jobs:
           maven-version: '3.8.6'
       - name: Run Checkstyle
         run: mvn -B verify checkstyle:check
-      - uses: jwgmeligmeyling/checkstyle-github-action@master
+      - name: Write Checkstyle Report
+        uses: jwgmeligmeyling/checkstyle-github-action@master
         if: failure()
         with:
           path: '**/checkstyle-result.xml'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           maven-version: '3.8.6'
       - name: Run Spotbugs
-        run: mvn com.github.spotbugs:spotbugs-maven-plugin:check
+        run: mvn -B verify spotbugs:check
 
   checkstyle-check:
     runs-on: ubuntu-latest
@@ -42,4 +42,4 @@ jobs:
         with:
           maven-version: '3.8.6'
       - name: Run Checkstyle
-        run: mvn org.apache.maven.plugins:maven-checkstyle-plugin:check
+        run: mvn -B verify checkstyle:check

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           maven-version: '3.8.6'
       - name: Run Spotbugs
-        run: mvn spotbugs-maven-plugin:check
+        run: mvn com.github.spotbugs:spotbugs-maven-plugin:check
 
   checkstyle-check:
     runs-on: ubuntu-latest
@@ -42,4 +42,4 @@ jobs:
         with:
           maven-version: '3.8.6'
       - name: Run Checkstyle
-        run: mvn maven-checkstyle-plugin:check
+        run: mvn org.apache.maven.plugins:maven-checkstyle-plugin:check

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,45 @@
+name: Code Style Check
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  spotbugs-check:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: 17
+          distribution: 'temurin'
+          cache: 'maven'
+      - name: Set up Maven
+        uses: stCarolas/setup-maven@v4
+        with:
+          maven-version: '3.8.6'
+      - name: Run Spotbugs
+        run: mvn spotbugs-maven-plugin:check
+
+  checkstyle-check:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: 17
+          distribution: 'temurin'
+          cache: 'maven'
+      - name: Set up Maven
+        uses: stCarolas/setup-maven@v4
+        with:
+          maven-version: '3.8.6'
+      - name: Run Checkstyle
+        run: mvn maven-checkstyle-plugin:check

--- a/pom.xml
+++ b/pom.xml
@@ -84,11 +84,6 @@
 			<artifactId>commons-csv</artifactId>
 			<version>1.8</version>
 		</dependency>
-		<dependency>
-			<groupId>com.puppycrawl.tools</groupId>
-			<artifactId>checkstyle</artifactId>
-			<version>10.18.1</version>
-		</dependency>
 	</dependencies>
 
 	<build>
@@ -114,6 +109,25 @@
 						<groupId>com.github.spotbugs</groupId>
 						<artifactId>spotbugs</artifactId>
 						<version>4.8.5</version>
+					</dependency>
+				</dependencies>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-checkstyle-plugin</artifactId>
+				<version>3.6.0</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>check</goal>
+						</goals>
+					</execution>
+				</executions>
+				<dependencies>
+					<dependency>
+						<groupId>com.puppycrawl.tools</groupId>
+						<artifactId>checkstyle</artifactId>
+						<version>10.18.1</version>
 					</dependency>
 				</dependencies>
 			</plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -116,13 +116,6 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-checkstyle-plugin</artifactId>
 				<version>3.6.0</version>
-				<executions>
-					<execution>
-						<goals>
-							<goal>check</goal>
-						</goals>
-					</execution>
-				</executions>
 				<dependencies>
 					<dependency>
 						<groupId>com.puppycrawl.tools</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -127,4 +127,19 @@
 		</plugins>
 	</build>
 
+	<reporting>
+		<plugins>
+			<plugin>
+				<groupId>com.github.spotbugs</groupId>
+				<artifactId>spotbugs-maven-plugin</artifactId>
+				<version>4.8.5.0</version>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-checkstyle-plugin</artifactId>
+				<version>3.6.0</version>
+			</plugin>
+		</plugins>
+	</reporting>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,11 @@
 			<artifactId>commons-csv</artifactId>
 			<version>1.8</version>
 		</dependency>
+		<dependency>
+			<groupId>com.puppycrawl.tools</groupId>
+			<artifactId>checkstyle</artifactId>
+			<version>10.18.1</version>
+		</dependency>
 	</dependencies>
 
 	<build>
@@ -99,6 +104,18 @@
 						</exclude>
 					</excludes>
 				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>com.github.spotbugs</groupId>
+				<artifactId>spotbugs-maven-plugin</artifactId>
+				<version>4.8.5.0</version>
+				<dependencies>
+					<dependency>
+						<groupId>com.github.spotbugs</groupId>
+						<artifactId>spotbugs</artifactId>
+						<version>4.8.5</version>
+					</dependency>
+				</dependencies>
 			</plugin>
 		</plugins>
 	</build>


### PR DESCRIPTION
Added Checkstyle and Spotbugs to the project with Github workflow script to automatically run style checks.

Currently, checkstyle is configured to use the default ruleset: `sun_checks.xml` (hence, there are a lot of errors reported by CI/CD). Also, I added a step in the action script to showcase any warnings and errors caught by checkstyle and spotbugs in a human readable format.

From my research Checkstyle and Spotbugs do not automatically resolve these styling errors, so maybe another pull request should be made to address those concerns.