### PR TITLE
Fixed bug causing querying `ServiceAtLocation` to stack overflow

### DIFF
--- a/src/main/java/com/sarapis/orservice/dto/ServiceAtLocationDTO.java
+++ b/src/main/java/com/sarapis/orservice/dto/ServiceAtLocationDTO.java
@@ -37,7 +37,7 @@ public class ServiceAtLocationDTO {
   public static class Response {
     private String id;
     private String description;
-    private ServiceDTO.Response service;
+    private ServiceDTO.Summary service;
     private LocationDTO.Response location;
     private List<ContactDTO.Response> contacts;
     private List<PhoneDTO.Response> phones;

--- a/src/main/java/com/sarapis/orservice/service/ServiceAtLocationServiceImpl.java
+++ b/src/main/java/com/sarapis/orservice/service/ServiceAtLocationServiceImpl.java
@@ -43,7 +43,10 @@ public class ServiceAtLocationServiceImpl implements ServiceAtLocationService {
     PageRequest pageable = PageRequest.of(page, perPage);
     Page<ServiceAtLocation> serviceAtLocationPage = serviceAtLocationRepository.findAll(spec, pageable);
     Page<ServiceAtLocationDTO.Response> dtoPage =
-        serviceAtLocationPage.map(serviceAtLocation -> serviceAtLocationMapper.toResponseDTO(serviceAtLocation, metadataService));
+        serviceAtLocationPage.map(serviceAtLocation -> {
+          serviceAtLocation.getService().setServiceAtLocations(null);
+          return serviceAtLocationMapper.toResponseDTO(serviceAtLocation, metadataService);
+        });
     return PaginationDTO.fromPage(dtoPage);
   }
 

--- a/src/main/java/com/sarapis/orservice/service/ServiceAtLocationServiceImpl.java
+++ b/src/main/java/com/sarapis/orservice/service/ServiceAtLocationServiceImpl.java
@@ -43,10 +43,7 @@ public class ServiceAtLocationServiceImpl implements ServiceAtLocationService {
     PageRequest pageable = PageRequest.of(page, perPage);
     Page<ServiceAtLocation> serviceAtLocationPage = serviceAtLocationRepository.findAll(spec, pageable);
     Page<ServiceAtLocationDTO.Response> dtoPage =
-        serviceAtLocationPage.map(serviceAtLocation -> {
-          serviceAtLocation.getService().setServiceAtLocations(null);
-          return serviceAtLocationMapper.toResponseDTO(serviceAtLocation, metadataService);
-        });
+        serviceAtLocationPage.map(serviceAtLocation -> serviceAtLocationMapper.toResponseDTO(serviceAtLocation, metadataService));
     return PaginationDTO.fromPage(dtoPage);
   }
 


### PR DESCRIPTION
The bug occurs in `ServiceAtLocationServiceImpl.java` when the class tries to map the paged entities to paged dtos. Since the `ServiceAtLocation` entity class contains a reference to the `Service` class and the `Service` class also contains a reference to the `ServiceAtLocation` entity, the auto-mapper is stuck converting again and again, causing a stack overflow. Fixed by simply setting the `Service` property to null before converting.